### PR TITLE
Function aliasing

### DIFF
--- a/src/Engine.js
+++ b/src/Engine.js
@@ -74,6 +74,16 @@ function Engine(
 
 _.extend(Engine.prototype, {
     /**
+     * Defines the given alias for the given function
+     *
+     * @param {string} originalName
+     * @param {string} aliasName
+     */
+    aliasFunction: function (originalName, aliasName) {
+        this.environment.aliasFunction(originalName, aliasName);
+    },
+
+    /**
      * Creates a new FFI Result, to provide the result of a call to a JS function
      *
      * @param {Function} syncCallback

--- a/src/Environment.js
+++ b/src/Environment.js
@@ -29,6 +29,16 @@ function Environment(state) {
 
 _.extend(Environment.prototype, {
     /**
+     * Defines the given alias for the given function
+     *
+     * @param {string} originalName
+     * @param {string} aliasName
+     */
+    aliasFunction: function (originalName, aliasName) {
+        this.state.aliasFunction(originalName, aliasName);
+    },
+
+    /**
      * Creates a new FFI Result, to provide the result of a call to a JS function
      *
      * @param {Function} syncCallback

--- a/src/Function/FunctionSpecFactory.js
+++ b/src/Function/FunctionSpecFactory.js
@@ -64,6 +64,31 @@ function FunctionSpecFactory(
 
 _.extend(FunctionSpecFactory.prototype, {
     /**
+     * Creates a FunctionSpec for a function alias
+     *
+     * @param {NamespaceScope} namespaceScope
+     * @param {string} functionName
+     * @param {Parameter[]} parameters
+     * @param {string|null} filePath
+     * @param {number|null} lineNumber
+     * @returns {FunctionSpec}
+     */
+    createAliasFunctionSpec: function (namespaceScope, functionName, parameters, filePath, lineNumber) {
+        var factory = this,
+            context = new factory.FunctionContext(namespaceScope, functionName);
+
+        return new factory.FunctionSpec(
+            factory.callStack,
+            factory.valueFactory,
+            context,
+            namespaceScope,
+            parameters,
+            filePath,
+            lineNumber
+        );
+    },
+
+    /**
      * Creates a FunctionSpec from the given spec data for a closure
      *
      * @param {NamespaceScope} namespaceScope
@@ -88,6 +113,7 @@ _.extend(FunctionSpecFactory.prototype, {
             factory.callStack,
             factory.valueFactory,
             context,
+            namespaceScope,
             parameters,
             filePath,
             lineNumber
@@ -119,6 +145,7 @@ _.extend(FunctionSpecFactory.prototype, {
             factory.callStack,
             factory.valueFactory,
             context,
+            namespaceScope,
             parameters,
             filePath,
             lineNumber
@@ -151,6 +178,7 @@ _.extend(FunctionSpecFactory.prototype, {
             factory.callStack,
             factory.valueFactory,
             context,
+            namespaceScope,
             parameters,
             filePath,
             lineNumber

--- a/src/FunctionFactory.js
+++ b/src/FunctionFactory.js
@@ -117,6 +117,7 @@ module.exports = require('pauser')([
 
             wrapperFunc.functionSpec = functionSpec;
             wrapperFunc.isPHPCoreWrapped = true;
+            wrapperFunc.originalFunc = func;
 
             return wrapperFunc;
         },

--- a/src/Namespace.js
+++ b/src/Namespace.js
@@ -118,6 +118,30 @@ module.exports = require('pauser')([
 
     _.extend(Namespace.prototype, {
         /**
+         * Defines the given alias for the given function
+         *
+         * @param {string} originalName
+         * @param {string} aliasName
+         */
+        aliasFunction: function (originalName, aliasName) {
+            var existingFunction,
+                namespace = this;
+
+            if (!namespace.hasFunction(originalName)) {
+                throw new Error('Cannot alias undefined function "' + originalName + '"');
+            }
+
+            existingFunction = namespace.getFunction(originalName);
+
+            namespace.functions[aliasName.toLowerCase()] = existingFunction.functionSpec.createAliasFunction(
+                aliasName,
+                existingFunction.originalFunc,
+                namespace.functionSpecFactory,
+                namespace.functionFactory
+            );
+        },
+
+        /**
          * Defines a class in the current namespace, either from a JS class/function or from a transpiled PHP class,
          * where PHPToJS has generated an object containing all the information related to the class
          *
@@ -666,10 +690,10 @@ module.exports = require('pauser')([
         },
 
         /**
-         * Parses a class, function or constant name to
+         * Parses a class, function or constant name to its namespace and name
          *
          * @param {string} name
-         * @returns {{namespace: (Namespace), name: string}|null}
+         * @returns {{namespace: (Namespace), name: string}}
          */
         parseName: function (name) {
             var match = name.match(/^(\\?)(.*?)\\?([^\\]+)$/),

--- a/test/integration/functionAliasingTest.js
+++ b/test/integration/functionAliasingTest.js
@@ -1,0 +1,52 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    nowdoc = require('nowdoc'),
+    tools = require('./tools');
+
+describe('PHP function aliasing integration', function () {
+    it('should support aliasing functions', function () {
+        var php,
+            module,
+            engine;
+
+        php = nowdoc(function () {/*<<<EOS
+<?php
+
+namespace My\Awesome\Space
+{
+    function myFunc($myArg) {
+        return $myArg . ' was passed to ' . __FUNCTION__;
+    }
+}
+
+namespace
+{
+    // Use our custom function to install the alias
+    function_alias('My\\Awesome\\Space\\myFunc', 'myAliasFunc');
+
+    return My\Awesome\Space\myAliasFunc(21);
+}
+EOS
+*/;}); //jshint ignore:line
+        module = tools.syncTranspile('/path/to/my_module.php', php);
+        engine = module();
+
+        engine.defineCoercingFunction('function_alias', function (originalName, aliasName) {
+            engine.aliasFunction(originalName, aliasName);
+        });
+
+        engine.execute();
+
+        expect(engine.execute().getNative()).to.equal('21 was passed to My\\Awesome\\Space\\myAliasFunc');
+    });
+});

--- a/test/unit/EngineTest.js
+++ b/test/unit/EngineTest.js
@@ -64,6 +64,17 @@ describe('Engine', function () {
         }.bind(this);
     });
 
+    describe('aliasFunction()', function () {
+        it('should alias the function via the Environment', function () {
+            this.createEngine();
+
+            this.engine.aliasFunction('originalFunc', 'aliasFunc');
+
+            expect(this.environment.aliasFunction).to.have.been.calledOnce;
+            expect(this.environment.aliasFunction).to.have.been.calledWith('originalFunc', 'aliasFunc');
+        });
+    });
+
     describe('createFFIResult()', function () {
         it('should create an FFI Result via the Environment', function () {
             var ffiResult = sinon.createStubInstance(FFIResult),

--- a/test/unit/EngineTest.js
+++ b/test/unit/EngineTest.js
@@ -21,57 +21,73 @@ var expect = require('chai').expect,
     ValueFactory = require('../../src/ValueFactory').sync();
 
 describe('Engine', function () {
+    var createEngine,
+        engine,
+        environment,
+        mode,
+        options,
+        pausable,
+        phpCommon,
+        phpToAST,
+        phpToJS,
+        state,
+        topLevelScope,
+        valueFactory,
+        whenPausableIsAvailable,
+        whenPausableIsNotAvailable,
+        wrapper;
+
     beforeEach(function () {
-        var mode = 'async';
-        this.environment = sinon.createStubInstance(Environment);
-        this.options = {};
-        this.pausable = {
+        mode = 'async';
+        environment = sinon.createStubInstance(Environment);
+        options = {};
+        pausable = {
             createPause: function () {
                 return sinon.createStubInstance(PauseException);
             }
         };
-        this.phpCommon = {};
-        this.phpToAST = {};
-        this.phpToJS = {};
-        this.state = sinon.createStubInstance(PHPState);
-        this.topLevelScope = sinon.createStubInstance(Scope);
-        this.valueFactory = new ValueFactory();
-        this.wrapper = sinon.stub();
+        phpCommon = {};
+        phpToAST = {};
+        phpToJS = {};
+        state = sinon.createStubInstance(PHPState);
+        topLevelScope = sinon.createStubInstance(Scope);
+        valueFactory = new ValueFactory();
+        wrapper = sinon.stub();
 
-        this.environment.getState.returns(this.state);
-        this.state.getValueFactory.returns(this.valueFactory);
+        environment.getState.returns(state);
+        state.getValueFactory.returns(valueFactory);
 
-        this.createEngine = function (customMode) {
-            this.engine = new Engine(
-                this.environment,
-                this.topLevelScope,
-                this.phpCommon,
-                this.options,
-                this.wrapper,
-                this.pausable,
+        createEngine = function (customMode) {
+            engine = new Engine(
+                environment,
+                topLevelScope,
+                phpCommon,
+                options,
+                wrapper,
+                pausable,
                 customMode || mode
             );
-        }.bind(this);
+        };
 
-        this.whenPausableIsAvailable = function () {
+        whenPausableIsAvailable = function () {
             mode = 'async';
-            this.createEngine();
-        }.bind(this);
-        this.whenPausableIsNotAvailable = function () {
+            createEngine();
+        };
+        whenPausableIsNotAvailable = function () {
             mode = 'sync';
-            this.pausable = null;
-            this.createEngine();
-        }.bind(this);
+            pausable = null;
+            createEngine();
+        };
     });
 
     describe('aliasFunction()', function () {
         it('should alias the function via the Environment', function () {
-            this.createEngine();
+            createEngine();
 
-            this.engine.aliasFunction('originalFunc', 'aliasFunc');
+            engine.aliasFunction('originalFunc', 'aliasFunc');
 
-            expect(this.environment.aliasFunction).to.have.been.calledOnce;
-            expect(this.environment.aliasFunction).to.have.been.calledWith('originalFunc', 'aliasFunc');
+            expect(environment.aliasFunction).to.have.been.calledOnce;
+            expect(environment.aliasFunction).to.have.been.calledWith('originalFunc', 'aliasFunc');
         });
     });
 
@@ -80,40 +96,40 @@ describe('Engine', function () {
             var ffiResult = sinon.createStubInstance(FFIResult),
                 asyncCallback = sinon.stub(),
                 syncCallback = sinon.stub();
-            this.environment.createFFIResult
+            environment.createFFIResult
                 .withArgs(sinon.match.same(syncCallback), sinon.match.same(asyncCallback))
                 .returns(ffiResult);
-            this.createEngine();
+            createEngine();
 
-            expect(this.engine.createFFIResult(syncCallback, asyncCallback)).to.equal(ffiResult);
+            expect(engine.createFFIResult(syncCallback, asyncCallback)).to.equal(ffiResult);
         });
     });
 
     describe('createPause()', function () {
         it('should return a PauseException when the Pausable library is available', function () {
-            this.whenPausableIsAvailable();
+            whenPausableIsAvailable();
 
-            expect(this.engine.createPause()).to.be.an.instanceOf(PauseException);
+            expect(engine.createPause()).to.be.an.instanceOf(PauseException);
         });
 
         it('should throw an exception when the Pausable library is not available', function () {
-            this.whenPausableIsNotAvailable();
+            whenPausableIsNotAvailable();
 
             expect(function () {
-                this.engine.createPause();
-            }.bind(this)).to.throw('Pausable is not available');
+                engine.createPause();
+            }).to.throw('Pausable is not available');
         });
     });
 
     describe('defineClass()', function () {
         it('should define a class on the environment', function () {
             var myClassDefinitionFactory = sinon.stub();
-            this.createEngine();
+            createEngine();
 
-            this.engine.defineClass('My\\Fqcn', myClassDefinitionFactory);
+            engine.defineClass('My\\Fqcn', myClassDefinitionFactory);
 
-            expect(this.environment.defineClass).to.have.been.calledOnce;
-            expect(this.environment.defineClass).to.have.been.calledWith(
+            expect(environment.defineClass).to.have.been.calledOnce;
+            expect(environment.defineClass).to.have.been.calledWith(
                 'My\\Fqcn',
                 sinon.match.same(myClassDefinitionFactory)
             );
@@ -122,12 +138,12 @@ describe('Engine', function () {
         it('should return the defined class from the environment', function () {
             var myClassDefinitionFactory = sinon.stub(),
                 myClassObject = sinon.createStubInstance(Class);
-            this.environment.defineClass
+            environment.defineClass
                 .withArgs('My\\Fqcn', sinon.match.same(myClassDefinitionFactory))
                 .returns(myClassObject);
-            this.createEngine();
+            createEngine();
 
-            expect(this.engine.defineClass('My\\Fqcn', myClassDefinitionFactory))
+            expect(engine.defineClass('My\\Fqcn', myClassDefinitionFactory))
                 .to.equal(myClassObject);
         });
     });
@@ -135,12 +151,12 @@ describe('Engine', function () {
     describe('defineCoercingFunction()', function () {
         it('should define a coercing function on the environment', function () {
             var myFunction = sinon.stub();
-            this.createEngine();
+            createEngine();
 
-            this.engine.defineCoercingFunction('my_func', myFunction);
+            engine.defineCoercingFunction('my_func', myFunction);
 
-            expect(this.environment.defineCoercingFunction).to.have.been.calledOnce;
-            expect(this.environment.defineCoercingFunction).to.have.been.calledWith(
+            expect(environment.defineCoercingFunction).to.have.been.calledOnce;
+            expect(environment.defineCoercingFunction).to.have.been.calledWith(
                 'my_func',
                 sinon.match.same(myFunction)
             );
@@ -149,12 +165,12 @@ describe('Engine', function () {
 
     describe('defineConstant()', function () {
         it('should define a constant on the environment', function () {
-            this.createEngine();
+            createEngine();
 
-            this.engine.defineConstant('MY_CONST', 21, {caseInsensitive: true});
+            engine.defineConstant('MY_CONST', 21, {caseInsensitive: true});
 
-            expect(this.environment.defineConstant).to.have.been.calledOnce;
-            expect(this.environment.defineConstant).to.have.been.calledWith(
+            expect(environment.defineConstant).to.have.been.calledOnce;
+            expect(environment.defineConstant).to.have.been.calledWith(
                 'MY_CONST',
                 21,
                 {caseInsensitive: true}
@@ -164,14 +180,14 @@ describe('Engine', function () {
 
     describe('defineGlobal()', function () {
         it('should define a global on the environment', function () {
-            this.createEngine();
+            createEngine();
 
-            this.engine.defineGlobal('my_global', 21);
+            engine.defineGlobal('my_global', 21);
 
-            expect(this.environment.defineGlobal).to.have.been.calledOnce;
-            expect(this.environment.defineGlobal).to.have.been.calledWith('my_global');
-            expect(this.environment.defineGlobal.args[0][1].getType()).to.equal('int');
-            expect(this.environment.defineGlobal.args[0][1].getNative()).to.equal(21);
+            expect(environment.defineGlobal).to.have.been.calledOnce;
+            expect(environment.defineGlobal).to.have.been.calledWith('my_global');
+            expect(environment.defineGlobal.args[0][1].getType()).to.equal('int');
+            expect(environment.defineGlobal.args[0][1].getNative()).to.equal(21);
         });
     });
 
@@ -179,12 +195,12 @@ describe('Engine', function () {
         it('should define a global accessor on the environment', function () {
             var valueGetter = sinon.stub(),
                 valueSetter = sinon.stub();
-            this.createEngine();
+            createEngine();
 
-            this.engine.defineGlobalAccessor('my_global', valueGetter, valueSetter);
+            engine.defineGlobalAccessor('my_global', valueGetter, valueSetter);
 
-            expect(this.environment.defineGlobalAccessor).to.have.been.calledOnce;
-            expect(this.environment.defineGlobalAccessor).to.have.been.calledWith(
+            expect(environment.defineGlobalAccessor).to.have.been.calledOnce;
+            expect(environment.defineGlobalAccessor).to.have.been.calledWith(
                 'my_global',
                 sinon.match.same(valueGetter),
                 sinon.match.same(valueSetter)
@@ -195,12 +211,12 @@ describe('Engine', function () {
     describe('defineNonCoercingFunction()', function () {
         it('should define a non-coercing function on the environment', function () {
             var myFunction = sinon.stub();
-            this.createEngine();
+            createEngine();
 
-            this.engine.defineNonCoercingFunction('my_func', myFunction);
+            engine.defineNonCoercingFunction('my_func', myFunction);
 
-            expect(this.environment.defineNonCoercingFunction).to.have.been.calledOnce;
-            expect(this.environment.defineNonCoercingFunction).to.have.been.calledWith(
+            expect(environment.defineNonCoercingFunction).to.have.been.calledOnce;
+            expect(environment.defineNonCoercingFunction).to.have.been.calledWith(
                 'my_func',
                 sinon.match.same(myFunction)
             );
@@ -211,12 +227,12 @@ describe('Engine', function () {
         it('should define the superglobal on the environment', function () {
             var valueGetter = sinon.stub(),
                 valueSetter = sinon.spy();
-            this.createEngine();
+            createEngine();
 
-            this.engine.defineSuperGlobalAccessor('MY_SUPER', valueGetter, valueSetter);
+            engine.defineSuperGlobalAccessor('MY_SUPER', valueGetter, valueSetter);
 
-            expect(this.environment.defineSuperGlobalAccessor).to.have.been.calledOnce;
-            expect(this.environment.defineSuperGlobalAccessor).to.have.been.calledWith(
+            expect(environment.defineSuperGlobalAccessor).to.have.been.calledOnce;
+            expect(environment.defineSuperGlobalAccessor).to.have.been.calledWith(
                 'MY_SUPER',
                 sinon.match.same(valueGetter),
                 sinon.match.same(valueSetter)
@@ -226,10 +242,10 @@ describe('Engine', function () {
 
     describe('getConstant()', function () {
         it('should return the value of the constant from the environment', function () {
-            this.createEngine();
-            this.environment.getConstant.withArgs('A_CONST').returns('my value');
+            createEngine();
+            environment.getConstant.withArgs('A_CONST').returns('my value');
 
-            expect(this.engine.getConstant('A_CONST')).to.equal('my value');
+            expect(engine.getConstant('A_CONST')).to.equal('my value');
         });
     });
 });

--- a/test/unit/EnvironmentTest.js
+++ b/test/unit/EnvironmentTest.js
@@ -29,6 +29,15 @@ describe('Environment', function () {
         this.environment = new Environment(this.state);
     });
 
+    describe('aliasFunction()', function () {
+        it('should alias the function via the PHPState', function () {
+            this.environment.aliasFunction('originalFunc', 'aliasFunc');
+
+            expect(this.state.aliasFunction).to.have.been.calledOnce;
+            expect(this.state.aliasFunction).to.have.been.calledWith('originalFunc', 'aliasFunc');
+        });
+    });
+
     describe('createFFIResult()', function () {
         beforeEach(function () {
             this.asyncCallback = sinon.stub();

--- a/test/unit/EnvironmentTest.js
+++ b/test/unit/EnvironmentTest.js
@@ -23,47 +23,55 @@ var expect = require('chai').expect,
     Value = require('../../src/Value').sync();
 
 describe('Environment', function () {
-    beforeEach(function () {
-        this.state = sinon.createStubInstance(PHPState);
+    var environment,
+        state;
 
-        this.environment = new Environment(this.state);
+    beforeEach(function () {
+        state = sinon.createStubInstance(PHPState);
+
+        environment = new Environment(state);
     });
 
     describe('aliasFunction()', function () {
         it('should alias the function via the PHPState', function () {
-            this.environment.aliasFunction('originalFunc', 'aliasFunc');
+            environment.aliasFunction('originalFunc', 'aliasFunc');
 
-            expect(this.state.aliasFunction).to.have.been.calledOnce;
-            expect(this.state.aliasFunction).to.have.been.calledWith('originalFunc', 'aliasFunc');
+            expect(state.aliasFunction).to.have.been.calledOnce;
+            expect(state.aliasFunction).to.have.been.calledWith('originalFunc', 'aliasFunc');
         });
     });
 
     describe('createFFIResult()', function () {
-        beforeEach(function () {
-            this.asyncCallback = sinon.stub();
-            this.syncCallback = sinon.stub();
+        var asyncCallback,
+            syncCallback;
 
-            this.syncCallback.returns(21);
-            this.asyncCallback.callsFake(function () {
+        beforeEach(function () {
+            asyncCallback = sinon.stub();
+            syncCallback = sinon.stub();
+
+            syncCallback.returns(21);
+            asyncCallback.callsFake(function () {
                 return Promise.resolve(101);
             });
         });
 
         it('should return an instance of FFI Result', function () {
-            expect(this.environment.createFFIResult(this.syncCallback, this.asyncCallback)).to.be.an.instanceOf(FFIResult);
+            expect(environment.createFFIResult(syncCallback, asyncCallback)).to.be.an.instanceOf(FFIResult);
         });
 
         describe('the instance of FFI Result returned', function () {
+            var ffiResult;
+
             beforeEach(function () {
-                this.ffiResult = this.environment.createFFIResult(this.syncCallback, this.asyncCallback);
+                ffiResult = environment.createFFIResult(syncCallback, asyncCallback);
             });
 
             it('should be passed the sync callback correctly', function () {
-                expect(this.ffiResult.getSync()).to.equal(21);
+                expect(ffiResult.getSync()).to.equal(21);
             });
 
             it('should be passed the async callback correctly', function () {
-                expect(this.ffiResult.getAsync()).to.eventually.equal(101);
+                expect(ffiResult.getAsync()).to.eventually.equal(101);
             });
         });
     });
@@ -72,10 +80,10 @@ describe('Environment', function () {
         it('should define the class on the state', function () {
             var definitionFactory = sinon.stub();
 
-            this.environment.defineClass('My\\Namespaced\\CoolClass', definitionFactory);
+            environment.defineClass('My\\Namespaced\\CoolClass', definitionFactory);
 
-            expect(this.state.defineClass).to.have.been.calledOnce;
-            expect(this.state.defineClass).to.have.been.calledWith(
+            expect(state.defineClass).to.have.been.calledOnce;
+            expect(state.defineClass).to.have.been.calledWith(
                 'My\\Namespaced\\CoolClass',
                 sinon.match.same(definitionFactory)
             );
@@ -86,10 +94,10 @@ describe('Environment', function () {
         it('should define the function on the state', function () {
             var myFunction = sinon.stub();
 
-            this.environment.defineCoercingFunction('my_func', myFunction);
+            environment.defineCoercingFunction('my_func', myFunction);
 
-            expect(this.state.defineCoercingFunction).to.have.been.calledOnce;
-            expect(this.state.defineCoercingFunction).to.have.been.calledWith(
+            expect(state.defineCoercingFunction).to.have.been.calledOnce;
+            expect(state.defineCoercingFunction).to.have.been.calledWith(
                 'my_func',
                 sinon.match.same(myFunction)
             );
@@ -98,10 +106,10 @@ describe('Environment', function () {
 
     describe('defineConstant()', function () {
         it('should define a constant on the state', function () {
-            this.environment.defineConstant('MY_CONST', 21, {caseInsensitive: true});
+            environment.defineConstant('MY_CONST', 21, {caseInsensitive: true});
 
-            expect(this.state.defineConstant).to.have.been.calledOnce;
-            expect(this.state.defineConstant).to.have.been.calledWith(
+            expect(state.defineConstant).to.have.been.calledOnce;
+            expect(state.defineConstant).to.have.been.calledWith(
                 'MY_CONST',
                 21,
                 {caseInsensitive: true}
@@ -112,10 +120,10 @@ describe('Environment', function () {
     describe('defineGlobal()', function () {
         it('should define the global on the state', function () {
             var value = sinon.createStubInstance(Value);
-            this.environment.defineGlobal('myGlobal', value);
+            environment.defineGlobal('myGlobal', value);
 
-            expect(this.state.defineGlobal).to.have.been.calledOnce;
-            expect(this.state.defineGlobal).to.have.been.calledWith(
+            expect(state.defineGlobal).to.have.been.calledOnce;
+            expect(state.defineGlobal).to.have.been.calledWith(
                 'myGlobal',
                 sinon.match.same(value)
             );
@@ -126,10 +134,10 @@ describe('Environment', function () {
         it('should define the global on the state', function () {
             var valueGetter = sinon.stub(),
                 valueSetter = sinon.spy();
-            this.environment.defineGlobalAccessor('myGlobal', valueGetter, valueSetter);
+            environment.defineGlobalAccessor('myGlobal', valueGetter, valueSetter);
 
-            expect(this.state.defineGlobalAccessor).to.have.been.calledOnce;
-            expect(this.state.defineGlobalAccessor).to.have.been.calledWith(
+            expect(state.defineGlobalAccessor).to.have.been.calledOnce;
+            expect(state.defineGlobalAccessor).to.have.been.calledWith(
                 'myGlobal',
                 sinon.match.same(valueGetter),
                 sinon.match.same(valueSetter)
@@ -141,10 +149,10 @@ describe('Environment', function () {
         it('should define the function on the state', function () {
             var myFunction = sinon.stub();
 
-            this.environment.defineNonCoercingFunction('my_func', myFunction);
+            environment.defineNonCoercingFunction('my_func', myFunction);
 
-            expect(this.state.defineNonCoercingFunction).to.have.been.calledOnce;
-            expect(this.state.defineNonCoercingFunction).to.have.been.calledWith(
+            expect(state.defineNonCoercingFunction).to.have.been.calledOnce;
+            expect(state.defineNonCoercingFunction).to.have.been.calledWith(
                 'my_func',
                 sinon.match.same(myFunction)
             );
@@ -154,10 +162,10 @@ describe('Environment', function () {
     describe('defineSuperGlobal()', function () {
         it('should define the super global on the state', function () {
             var value = sinon.createStubInstance(Value);
-            this.environment.defineSuperGlobal('myGlobal', value);
+            environment.defineSuperGlobal('myGlobal', value);
 
-            expect(this.state.defineSuperGlobal).to.have.been.calledOnce;
-            expect(this.state.defineSuperGlobal).to.have.been.calledWith(
+            expect(state.defineSuperGlobal).to.have.been.calledOnce;
+            expect(state.defineSuperGlobal).to.have.been.calledWith(
                 'myGlobal',
                 sinon.match.same(value)
             );
@@ -168,10 +176,10 @@ describe('Environment', function () {
         it('should define the super global on the state', function () {
             var valueGetter = sinon.stub(),
                 valueSetter = sinon.spy();
-            this.environment.defineSuperGlobalAccessor('myGlobal', valueGetter, valueSetter);
+            environment.defineSuperGlobalAccessor('myGlobal', valueGetter, valueSetter);
 
-            expect(this.state.defineSuperGlobalAccessor).to.have.been.calledOnce;
-            expect(this.state.defineSuperGlobalAccessor).to.have.been.calledWith(
+            expect(state.defineSuperGlobalAccessor).to.have.been.calledOnce;
+            expect(state.defineSuperGlobalAccessor).to.have.been.calledWith(
                 'myGlobal',
                 sinon.match.same(valueGetter),
                 sinon.match.same(valueSetter)
@@ -181,9 +189,9 @@ describe('Environment', function () {
 
     describe('getConstant()', function () {
         it('should return the constant from the state', function () {
-            this.state.getConstant.withArgs('MY_CONST').returns(21);
+            state.getConstant.withArgs('MY_CONST').returns(21);
 
-            expect(this.environment.getConstant('MY_CONST')).to.equal(21);
+            expect(environment.getConstant('MY_CONST')).to.equal(21);
         });
     });
 
@@ -191,20 +199,22 @@ describe('Environment', function () {
         it('should return the raw options object from the PHPState', function () {
             var options = {'my-option': 27};
 
-            this.state.getOptions.returns(options);
+            state.getOptions.returns(options);
 
-            expect(this.environment.getOptions()).to.deep.equal(options);
+            expect(environment.getOptions()).to.deep.equal(options);
         });
     });
 
     describe('reportError()', function () {
+        var errorReporting;
+
         beforeEach(function () {
-            this.errorReporting = sinon.createStubInstance(ErrorReporting);
-            this.state.getErrorReporting.returns(this.errorReporting);
+            errorReporting = sinon.createStubInstance(ErrorReporting);
+            state.getErrorReporting.returns(errorReporting);
         });
 
         it('should report a PHPFatalError via ErrorReporting correctly', function () {
-            this.environment.reportError(
+            environment.reportError(
                 new PHPFatalError(
                     'My fatal error message',
                     '/path/to/my_module.php',
@@ -212,8 +222,8 @@ describe('Environment', function () {
                 )
             );
 
-            expect(this.errorReporting.reportError).to.have.been.calledOnce;
-            expect(this.errorReporting.reportError).to.have.been.calledWith(
+            expect(errorReporting.reportError).to.have.been.calledOnce;
+            expect(errorReporting.reportError).to.have.been.calledWith(
                 PHPError.E_ERROR,
                 'My fatal error message',
                 '/path/to/my_module.php',
@@ -224,7 +234,7 @@ describe('Environment', function () {
         });
 
         it('should report a PHPParseError via ErrorReporting correctly', function () {
-            this.environment.reportError(
+            environment.reportError(
                 new PHPParseError(
                     'My parse error message',
                     '/path/to/my_module.php',
@@ -232,8 +242,8 @@ describe('Environment', function () {
                 )
             );
 
-            expect(this.errorReporting.reportError).to.have.been.calledOnce;
-            expect(this.errorReporting.reportError).to.have.been.calledWith(
+            expect(errorReporting.reportError).to.have.been.calledOnce;
+            expect(errorReporting.reportError).to.have.been.calledWith(
                 PHPError.E_PARSE,
                 'My parse error message',
                 '/path/to/my_module.php',
@@ -245,8 +255,8 @@ describe('Environment', function () {
 
         it('should throw when an unsupported type of error is given', function () {
             expect(function () {
-                this.environment.reportError(new Error('I am not a PHPError'));
-            }.bind(this)).to.throw('Invalid error type given');
+                environment.reportError(new Error('I am not a PHPError'));
+            }).to.throw('Invalid error type given');
         });
     });
 });

--- a/test/unit/Function/FunctionSpecFactoryTest.js
+++ b/test/unit/Function/FunctionSpecFactoryTest.js
@@ -54,6 +54,45 @@ describe('FunctionSpecFactory', function () {
         );
     });
 
+    describe('createAliasFunctionSpec()', function () {
+        var functionContext,
+            functionSpec,
+            parameter1,
+            parameter2;
+
+        beforeEach(function () {
+            functionContext = sinon.createStubInstance(FunctionContext);
+            functionSpec = sinon.createStubInstance(FunctionSpec);
+            parameter1 = sinon.createStubInstance(Parameter);
+            parameter2 = sinon.createStubInstance(Parameter);
+
+            FunctionContext
+                .withArgs(sinon.match.same(namespaceScope), 'myFunction')
+                .returns(functionContext);
+            FunctionSpec
+                .withArgs(
+                    sinon.match.same(callStack),
+                    sinon.match.same(valueFactory),
+                    sinon.match.same(functionContext),
+                    sinon.match.same(namespaceScope),
+                    [sinon.match.same(parameter1), sinon.match.same(parameter2)],
+                    '/path/to/my/module.php',
+                    123
+                )
+                .returns(functionSpec);
+        });
+
+        it('should return a correctly constructed FunctionSpec', function () {
+            expect(factory.createAliasFunctionSpec(
+                namespaceScope,
+                'myFunction',
+                [parameter1, parameter2],
+                '/path/to/my/module.php',
+                123
+            )).to.equal(functionSpec);
+        });
+    });
+
     describe('createClosureSpec()', function () {
         var closureContext,
             functionSpec,
@@ -99,6 +138,7 @@ describe('FunctionSpecFactory', function () {
                     sinon.match.same(callStack),
                     sinon.match.same(valueFactory),
                     sinon.match.same(closureContext),
+                    sinon.match.same(namespaceScope),
                     [sinon.match.same(parameter1), sinon.match.same(parameter2)],
                     '/path/to/my/module.php',
                     123
@@ -123,6 +163,7 @@ describe('FunctionSpecFactory', function () {
                     sinon.match.same(callStack),
                     sinon.match.same(valueFactory),
                     sinon.match.same(closureContext),
+                    sinon.match.same(namespaceScope),
                     [sinon.match.same(parameter1), sinon.match.same(parameter2)],
                     '/path/to/my/module.php',
                     123
@@ -181,6 +222,7 @@ describe('FunctionSpecFactory', function () {
                     sinon.match.same(callStack),
                     sinon.match.same(valueFactory),
                     sinon.match.same(functionContext),
+                    sinon.match.same(namespaceScope),
                     [sinon.match.same(parameter1), sinon.match.same(parameter2)],
                     '/path/to/my/module.php',
                     123
@@ -243,6 +285,7 @@ describe('FunctionSpecFactory', function () {
                     sinon.match.same(callStack),
                     sinon.match.same(valueFactory),
                     sinon.match.same(methodContext),
+                    sinon.match.same(namespaceScope),
                     [sinon.match.same(parameter1), sinon.match.same(parameter2)],
                     '/path/to/my/module.php',
                     123

--- a/test/unit/FunctionFactoryTest.js
+++ b/test/unit/FunctionFactoryTest.js
@@ -70,10 +70,6 @@ describe('FunctionFactory', function () {
             }.bind(this);
         });
 
-        it('should store the FunctionSpec against the function', function () {
-            expect(this.callCreate().functionSpec.getFunctionName()).to.equal('myFunction');
-        });
-
         it('should return a wrapper function', function () {
             expect(this.callCreate()).to.be.a('function');
         });
@@ -315,6 +311,18 @@ describe('FunctionFactory', function () {
                     sinon.match.same(argValue2),
                     sinon.match.same(argValue3)
                 );
+            });
+
+            it('should have the FunctionSpec stored against it', function () {
+                expect(this.callCreate().functionSpec).to.equal(this.functionSpec);
+            });
+
+            it('should have the isPHPCoreWrapped flag set against it', function () {
+                expect(this.callCreate().isPHPCoreWrapped).to.be.true;
+            });
+
+            it('should have the original function stored against it', function () {
+                expect(this.callCreate().originalFunc).to.equal(this.func);
             });
         });
     });

--- a/test/unit/FunctionFactoryTest.js
+++ b/test/unit/FunctionFactoryTest.js
@@ -24,79 +24,95 @@ var expect = require('chai').expect,
     ValueFactory = require('../../src/ValueFactory').sync();
 
 describe('FunctionFactory', function () {
+    var call,
+        callFactory,
+        callStack,
+        currentClass,
+        factory,
+        MethodSpec,
+        name,
+        namespaceScope,
+        originalFunc,
+        scope,
+        scopeFactory,
+        valueFactory;
+
     beforeEach(function () {
-        this.call = sinon.createStubInstance(Call);
-        this.callFactory = sinon.createStubInstance(CallFactory);
-        this.callStack = sinon.createStubInstance(CallStack);
-        this.currentClass = sinon.createStubInstance(Class);
-        this.func = sinon.stub();
-        this.MethodSpec = sinon.stub();
-        this.name = 'myFunction';
-        this.namespaceScope = sinon.createStubInstance(NamespaceScope);
-        this.scope = sinon.createStubInstance(Scope);
-        this.scopeFactory = sinon.createStubInstance(ScopeFactory);
-        this.valueFactory = new ValueFactory();
+        call = sinon.createStubInstance(Call);
+        callFactory = sinon.createStubInstance(CallFactory);
+        callStack = sinon.createStubInstance(CallStack);
+        currentClass = sinon.createStubInstance(Class);
+        originalFunc = sinon.stub();
+        MethodSpec = sinon.stub();
+        name = 'myFunction';
+        namespaceScope = sinon.createStubInstance(NamespaceScope);
+        scope = sinon.createStubInstance(Scope);
+        scopeFactory = sinon.createStubInstance(ScopeFactory);
+        valueFactory = new ValueFactory();
 
-        this.callFactory.create.returns(this.call);
-        this.scopeFactory.create.returns(this.scope);
+        callFactory.create.returns(call);
+        scopeFactory.create.returns(scope);
 
-        this.factory = new FunctionFactory(
-            this.MethodSpec,
-            this.scopeFactory,
-            this.callFactory,
-            this.valueFactory,
-            this.callStack
+        factory = new FunctionFactory(
+            MethodSpec,
+            scopeFactory,
+            callFactory,
+            valueFactory,
+            callStack
         );
     });
 
     describe('create()', function () {
+        var callCreate,
+            functionSpec;
+
         beforeEach(function () {
-            this.functionSpec = sinon.createStubInstance(FunctionSpec);
+            functionSpec = sinon.createStubInstance(FunctionSpec);
 
-            this.callCreate = function (currentObject, staticClass) {
-                this.functionSpec.coerceArguments.returnsArg(0);
-                this.functionSpec.populateDefaultArguments.returnsArg(0);
-                this.functionSpec.getFunctionName.returns(this.name);
+            callCreate = function (currentObject, staticClass) {
+                functionSpec.coerceArguments.returnsArg(0);
+                functionSpec.populateDefaultArguments.returnsArg(0);
+                functionSpec.getFunctionName.returns(name);
 
-                return this.factory.create(
-                    this.namespaceScope,
-                    this.currentClass,
-                    this.func,
-                    this.name,
+                return factory.create(
+                    namespaceScope,
+                    currentClass,
+                    originalFunc,
+                    name,
                     currentObject || null,
                     staticClass || null,
-                    this.functionSpec
+                    functionSpec
                 );
-            }.bind(this);
+            };
         });
 
         it('should return a wrapper function', function () {
-            expect(this.callCreate()).to.be.a('function');
+            expect(callCreate()).to.be.a('function');
         });
 
         describe('the wrapper function returned', function () {
             it('should return the result from the wrapped function', function () {
-                this.func.returns(123);
+                originalFunc.returns(123);
 
-                expect(this.callCreate()()).to.equal(123);
+                expect(callCreate()()).to.equal(123);
             });
 
             it('should pass the current Class to the ScopeFactory', function () {
-                this.callCreate()();
+                callCreate()();
 
-                expect(this.scopeFactory.create).to.have.been.calledOnce;
-                expect(this.scopeFactory.create).to.have.been.calledWith(
-                    sinon.match.same(this.currentClass)
+                expect(scopeFactory.create).to.have.been.calledOnce;
+                expect(scopeFactory.create).to.have.been.calledWith(
+                    sinon.match.same(currentClass)
                 );
             });
 
             it('should pass the wrapper function to the ScopeFactory', function () {
-                var wrapperFunction = this.callCreate();
+                var wrapperFunction = callCreate();
 
                 wrapperFunction();
 
-                expect(this.scopeFactory.create).to.have.been.calledOnce;
-                expect(this.scopeFactory.create).to.have.been.calledWith(
+                expect(scopeFactory.create).to.have.been.calledOnce;
+                expect(scopeFactory.create).to.have.been.calledWith(
                     sinon.match.any,
                     sinon.match.same(wrapperFunction)
                 );
@@ -105,10 +121,10 @@ describe('FunctionFactory', function () {
             it('should pass the `$this` object to the ScopeFactory when provided', function () {
                 var currentObject = sinon.createStubInstance(Value);
 
-                this.callCreate(currentObject)();
+                callCreate(currentObject)();
 
-                expect(this.scopeFactory.create).to.have.been.calledOnce;
-                expect(this.scopeFactory.create).to.have.been.calledWith(
+                expect(scopeFactory.create).to.have.been.calledOnce;
+                expect(scopeFactory.create).to.have.been.calledWith(
                     sinon.match.any,
                     sinon.match.any,
                     sinon.match.same(currentObject)
@@ -118,33 +134,33 @@ describe('FunctionFactory', function () {
             it('should pass the Scope to the CallFactory', function () {
                 var currentObject = sinon.createStubInstance(Value);
 
-                this.callCreate(currentObject)();
+                callCreate(currentObject)();
 
-                expect(this.callFactory.create).to.have.been.calledOnce;
-                expect(this.callFactory.create).to.have.been.calledWith(
-                    sinon.match.same(this.scope)
+                expect(callFactory.create).to.have.been.calledOnce;
+                expect(callFactory.create).to.have.been.calledWith(
+                    sinon.match.same(scope)
                 );
             });
 
             it('should pass the NamespaceScope to the CallFactory', function () {
                 var currentObject = sinon.createStubInstance(Value);
 
-                this.callCreate(currentObject)();
+                callCreate(currentObject)();
 
-                expect(this.callFactory.create).to.have.been.calledOnce;
-                expect(this.callFactory.create).to.have.been.calledWith(
+                expect(callFactory.create).to.have.been.calledOnce;
+                expect(callFactory.create).to.have.been.calledWith(
                     sinon.match.any,
-                    sinon.match.same(this.namespaceScope)
+                    sinon.match.same(namespaceScope)
                 );
             });
 
             it('should pass the arguments to the CallFactory', function () {
                 var currentObject = sinon.createStubInstance(Value);
 
-                this.callCreate(currentObject)(21, 27);
+                callCreate(currentObject)(21, 27);
 
-                expect(this.callFactory.create).to.have.been.calledOnce;
-                expect(this.callFactory.create).to.have.been.calledWith(
+                expect(callFactory.create).to.have.been.calledOnce;
+                expect(callFactory.create).to.have.been.calledWith(
                     sinon.match.any,
                     sinon.match.any,
                     [21, 27]
@@ -153,13 +169,13 @@ describe('FunctionFactory', function () {
 
             it('should pass any "next" static class set', function () {
                 var newStaticClass = sinon.createStubInstance(Class),
-                    func = this.callCreate();
-                this.factory.setNewStaticClassIfWrapped(func, newStaticClass);
+                    wrappedFunc = callCreate();
+                factory.setNewStaticClassIfWrapped(wrappedFunc, newStaticClass);
 
-                func();
+                wrappedFunc();
 
-                expect(this.callFactory.create).to.have.been.calledOnce;
-                expect(this.callFactory.create).to.have.been.calledWith(
+                expect(callFactory.create).to.have.been.calledOnce;
+                expect(callFactory.create).to.have.been.calledWith(
                     sinon.match.any,
                     sinon.match.any,
                     sinon.match.any,
@@ -170,10 +186,10 @@ describe('FunctionFactory', function () {
             it('should pass any explicit static class set', function () {
                 var explicitStaticClass = sinon.createStubInstance(Class);
 
-                this.callCreate(null, explicitStaticClass)();
+                callCreate(null, explicitStaticClass)();
 
-                expect(this.callFactory.create).to.have.been.calledOnce;
-                expect(this.callFactory.create).to.have.been.calledWith(
+                expect(callFactory.create).to.have.been.calledOnce;
+                expect(callFactory.create).to.have.been.calledWith(
                     sinon.match.any,
                     sinon.match.any,
                     sinon.match.any,
@@ -182,10 +198,10 @@ describe('FunctionFactory', function () {
             });
 
             it('should pass null as the new static class when no explicit or "next" one is set', function () {
-                this.callCreate()();
+                callCreate()();
 
-                expect(this.callFactory.create).to.have.been.calledOnce;
-                expect(this.callFactory.create).to.have.been.calledWith(
+                expect(callFactory.create).to.have.been.calledOnce;
+                expect(callFactory.create).to.have.been.calledWith(
                     sinon.match.any,
                     sinon.match.any,
                     sinon.match.any,
@@ -196,10 +212,10 @@ describe('FunctionFactory', function () {
             it('should pass the (JS) `this` object as the (PHP) `$this` object when not provided', function () {
                 var jsThisObjectValue = sinon.createStubInstance(Value);
 
-                this.callCreate(null).call(jsThisObjectValue);
+                callCreate(null).call(jsThisObjectValue);
 
-                expect(this.scopeFactory.create).to.have.been.calledOnce;
-                expect(this.scopeFactory.create).to.have.been.calledWith(
+                expect(scopeFactory.create).to.have.been.calledOnce;
+                expect(scopeFactory.create).to.have.been.calledWith(
                     sinon.match.any,
                     sinon.match.any,
                     sinon.match.same(jsThisObjectValue)
@@ -209,10 +225,10 @@ describe('FunctionFactory', function () {
             it('should pass null as the `$this` object when not provided and a non-Value (JS) `this` object was used', function () {
                 var nonValueThisObject = {};
 
-                this.callCreate(null).call(nonValueThisObject);
+                callCreate(null).call(nonValueThisObject);
 
-                expect(this.scopeFactory.create).to.have.been.calledOnce;
-                expect(this.scopeFactory.create).to.have.been.calledWith(
+                expect(scopeFactory.create).to.have.been.calledOnce;
+                expect(scopeFactory.create).to.have.been.calledWith(
                     sinon.match.any,
                     sinon.match.any,
                     null
@@ -220,93 +236,93 @@ describe('FunctionFactory', function () {
             });
 
             it('should coerce parameter arguments as required', function () {
-                var argValue1 = this.valueFactory.createInteger(21),
-                    argValue2 = this.valueFactory.createInteger(101),
-                    coercedArgValue1 = this.valueFactory.createInteger(42),
-                    coercedArgValue2 = this.valueFactory.createInteger(202),
-                    func = this.callCreate();
-                this.functionSpec.coerceArguments
+                var argValue1 = valueFactory.createInteger(21),
+                    argValue2 = valueFactory.createInteger(101),
+                    coercedArgValue1 = valueFactory.createInteger(42),
+                    coercedArgValue2 = valueFactory.createInteger(202),
+                    wrappedFunc = callCreate();
+                functionSpec.coerceArguments
                     .withArgs([sinon.match.same(argValue1), sinon.match.same(argValue2)])
                     .returns([coercedArgValue1, coercedArgValue2]);
 
-                func(argValue1, argValue2);
+                wrappedFunc(argValue1, argValue2);
 
-                expect(this.func).to.have.been.calledOnce;
-                expect(this.func).to.have.been.calledWith(coercedArgValue1, coercedArgValue2);
+                expect(originalFunc).to.have.been.calledOnce;
+                expect(originalFunc).to.have.been.calledWith(coercedArgValue1, coercedArgValue2);
             });
 
             it('should push the call onto the stack', function () {
-                this.callCreate()();
+                callCreate()();
 
-                expect(this.callStack.push).to.have.been.calledOnce;
-                expect(this.callStack.push).to.have.been.calledWith(sinon.match.same(this.call));
+                expect(callStack.push).to.have.been.calledOnce;
+                expect(callStack.push).to.have.been.calledWith(sinon.match.same(call));
             });
 
             it('should validate parameter arguments at the right point', function () {
-                var argValue1 = this.valueFactory.createInteger(21),
-                    argValue2 = this.valueFactory.createInteger(101),
-                    func = this.callCreate();
+                var argValue1 = valueFactory.createInteger(21),
+                    argValue2 = valueFactory.createInteger(101),
+                    wrappedFunc = callCreate();
 
-                func(argValue1, argValue2);
+                wrappedFunc(argValue1, argValue2);
 
-                expect(this.functionSpec.validateArguments).to.have.been.calledOnce;
-                expect(this.functionSpec.validateArguments).to.have.been.calledWith([
+                expect(functionSpec.validateArguments).to.have.been.calledOnce;
+                expect(functionSpec.validateArguments).to.have.been.calledWith([
                     sinon.match.same(argValue1),
                     sinon.match.same(argValue2)
                 ]);
-                expect(this.functionSpec.validateArguments)
-                    .to.have.been.calledAfter(this.functionSpec.coerceArguments);
+                expect(functionSpec.validateArguments)
+                    .to.have.been.calledAfter(functionSpec.coerceArguments);
             });
 
             it('should populate default argument values at the right point', function () {
-                var argValue1 = this.valueFactory.createInteger(21),
-                    argValue2 = this.valueFactory.createInteger(101),
-                    func = this.callCreate();
+                var argValue1 = valueFactory.createInteger(21),
+                    argValue2 = valueFactory.createInteger(101),
+                    wrappedFunc = callCreate();
 
-                func(argValue1, argValue2);
+                wrappedFunc(argValue1, argValue2);
 
-                expect(this.functionSpec.populateDefaultArguments).to.have.been.calledOnce;
-                expect(this.functionSpec.populateDefaultArguments).to.have.been.calledWith([
+                expect(functionSpec.populateDefaultArguments).to.have.been.calledOnce;
+                expect(functionSpec.populateDefaultArguments).to.have.been.calledWith([
                     sinon.match.same(argValue1),
                     sinon.match.same(argValue2)
                 ]);
-                expect(this.functionSpec.populateDefaultArguments)
-                    .to.have.been.calledAfter(this.functionSpec.validateArguments);
-                expect(this.functionSpec.populateDefaultArguments)
-                    .to.have.been.calledBefore(this.callStack.pop);
+                expect(functionSpec.populateDefaultArguments)
+                    .to.have.been.calledAfter(functionSpec.validateArguments);
+                expect(functionSpec.populateDefaultArguments)
+                    .to.have.been.calledBefore(callStack.pop);
             });
 
             it('should pop the call off the stack when the wrapped function returns', function () {
-                this.callCreate()();
+                callCreate()();
 
-                expect(this.callStack.pop).to.have.been.calledOnce;
+                expect(callStack.pop).to.have.been.calledOnce;
             });
 
             it('should pop the call off the stack even when the wrapped function throws', function () {
                 var error = new Error('argh');
-                this.func.throws(error);
+                originalFunc.throws(error);
 
                 expect(function () {
-                    this.callCreate()();
-                }.bind(this)).to.throw(error);
-                expect(this.callStack.pop).to.have.been.calledOnce;
+                    callCreate()();
+                }).to.throw(error);
+                expect(callStack.pop).to.have.been.calledOnce;
             });
 
             it('should pass the scope as the thisObject when calling the wrapped function', function () {
-                this.callCreate()();
+                callCreate()();
 
-                expect(this.func).to.have.been.calledOn(sinon.match.same(this.scope));
+                expect(originalFunc).to.have.been.calledOn(sinon.match.same(scope));
             });
 
             it('should pass arguments through to the wrapped function', function () {
-                var argValue1 = this.valueFactory.createInteger(123),
-                    argValue2 = this.valueFactory.createString('second'),
-                    argValue3 = this.valueFactory.createString('another');
+                var argValue1 = valueFactory.createInteger(123),
+                    argValue2 = valueFactory.createString('second'),
+                    argValue3 = valueFactory.createString('another');
 
-                this.callCreate()(argValue1, argValue2, argValue3);
+                callCreate()(argValue1, argValue2, argValue3);
 
-                expect(this.func).to.have.been.calledOnce;
-                expect(this.func).to.have.been.calledWith(
+                expect(originalFunc).to.have.been.calledOnce;
+                expect(originalFunc).to.have.been.calledWith(
                     sinon.match.same(argValue1),
                     sinon.match.same(argValue2),
                     sinon.match.same(argValue3)
@@ -314,15 +330,15 @@ describe('FunctionFactory', function () {
             });
 
             it('should have the FunctionSpec stored against it', function () {
-                expect(this.callCreate().functionSpec).to.equal(this.functionSpec);
+                expect(callCreate().functionSpec).to.equal(functionSpec);
             });
 
             it('should have the isPHPCoreWrapped flag set against it', function () {
-                expect(this.callCreate().isPHPCoreWrapped).to.be.true;
+                expect(callCreate().isPHPCoreWrapped).to.be.true;
             });
 
             it('should have the original function stored against it', function () {
-                expect(this.callCreate().originalFunc).to.equal(this.func);
+                expect(callCreate().originalFunc).to.equal(originalFunc);
             });
         });
     });
@@ -333,10 +349,10 @@ describe('FunctionFactory', function () {
                 myMethod = sinon.stub(),
                 originalClass = sinon.createStubInstance(Class);
 
-            this.factory.createMethodSpec(originalClass, classObject, 'myMethod', myMethod);
+            factory.createMethodSpec(originalClass, classObject, 'myMethod', myMethod);
 
-            expect(this.MethodSpec).to.have.been.calledOnce;
-            expect(this.MethodSpec).to.have.been.calledWith(
+            expect(MethodSpec).to.have.been.calledOnce;
+            expect(MethodSpec).to.have.been.calledWith(
                 sinon.match.same(originalClass),
                 sinon.match.same(classObject),
                 'myMethod',
@@ -346,12 +362,12 @@ describe('FunctionFactory', function () {
 
         it('should return the created MethodSpec', function () {
             var classObject = sinon.createStubInstance(Class),
-                methodSpec = sinon.createStubInstance(this.MethodSpec),
+                methodSpec = sinon.createStubInstance(MethodSpec),
                 myMethod = sinon.stub(),
                 originalClass = sinon.createStubInstance(Class);
-            this.MethodSpec.returns(methodSpec);
+            MethodSpec.returns(methodSpec);
 
-            expect(this.factory.createMethodSpec(originalClass, classObject, 'myMethod', myMethod)).to.equal(methodSpec);
+            expect(factory.createMethodSpec(originalClass, classObject, 'myMethod', myMethod)).to.equal(methodSpec);
         });
     });
 });


### PR DESCRIPTION
Adds support for defining an alias of an existing function. This can be done in one of two ways:
- Using the `.install(...)` API by passing a string (the original function's name) as the value rather than a function
- Using the `.aliasFunction(...)` public API on the `Engine` or `Environment` instance