### PR TITLE
Various platform-wide improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        strategy:
+            matrix:
+                node-version: [8.x, 10.x, 12.x]
+
+        steps:
+            # Check out the repository under $GITHUB_WORKSPACE, so this job can access it
+            - uses: actions/checkout@v2
+
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v1
+              with:
+                  node-version: ${{ matrix.node-version }}
+
+            - name: Install NPM dependencies
+              run: npm ci
+
+            - name: Run tests
+              run: npm test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,3 +24,6 @@ jobs:
 
             - name: Run tests
               run: npm test
+              env:
+                  # Raise the Node.js memory limit
+                  NODE_OPTIONS: --max-old-space-size=4096

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: node_js
-
-node_js:
-    - "8"
-
-env:
-    global:
-        # Raise the Node.js memory limit
-        - NODE_OPTIONS=--max-old-space-size=4096

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 PHPCore
 =======
 
-[![Build Status](https://secure.travis-ci.org/uniter/phpcore.png?branch=master)](http://travis-ci.org/uniter/phpcore)
+[![Build Status](https://github.com/uniter/phpcore/workflows/CI/badge.svg)](https://github.com/uniter/phpcore/actions?query=workflow%3ACI)
 
 Minimal PHP core library for PHP environments.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@sinonjs/commons": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
-      "integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -103,9 +103,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
     "brace-expansion": {
@@ -367,9 +367,9 @@
           "dev": true
         },
         "entities": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
           "dev": true
         }
       }
@@ -412,22 +412,22 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-to-primitive": {
@@ -513,9 +513,9 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
-      "integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
       "requires": {
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
@@ -739,9 +739,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
       "dev": true
     },
     "is-date-object": {
@@ -783,12 +783,12 @@
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
     "is-regex": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+      "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
       "dev": true,
       "requires": {
-        "has": "^1.0.3"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-symbol": {
@@ -823,16 +823,16 @@
       }
     },
     "jshint": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.11.0.tgz",
-      "integrity": "sha512-ooaD/hrBPhu35xXW4gn+o3SOuzht73gdBuffgJzrZBJZPGgGiiTvJEgTyxFvBO2nz0+X1G6etF8SzUODTlLY6Q==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.12.0.tgz",
+      "integrity": "sha512-TwuuaUDmra0JMkuqvqy+WGo2xGHSNjv1BA1nTIgtH2K5z1jHuAEeAgp7laaR+hLRmajRjcrM71+vByBDanCyYA==",
       "dev": true,
       "requires": {
         "cli": "~1.0.0",
         "console-browserify": "1.1.x",
         "exit": "0.1.x",
         "htmlparser2": "3.8.x",
-        "lodash": "~4.17.11",
+        "lodash": "~4.17.19",
         "minimatch": "~3.0.2",
         "shelljs": "0.3.x",
         "strip-json-comments": "1.0.x"
@@ -872,9 +872,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash.get": {
@@ -899,9 +899,9 @@
       "dev": true
     },
     "microdash": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/microdash/-/microdash-1.3.0.tgz",
-      "integrity": "sha1-TQ0yKY1UllS9lIhGAzkzqBwdkjs="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/microdash/-/microdash-1.4.1.tgz",
+      "integrity": "sha512-NJz1FkkTucluPbIzxkuLutzFTI3WWGJ8iOBAJIO49oHK19YkAOR/q8/XASiYS8J8OK8zGpxSD6/j/+M90gqdsQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -928,9 +928,9 @@
       }
     },
     "mocha": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.2.tgz",
-      "integrity": "sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+      "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -1053,9 +1053,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
       "dev": true
     },
     "object-keys": {
@@ -1133,12 +1133,12 @@
       "dev": true
     },
     "parsing": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parsing/-/parsing-2.0.0.tgz",
-      "integrity": "sha512-kGbuWxnoJhyrq5PJK59i9Gb1VfN1+n/3j1vQSXGviPdZsAbNGsJi4/VX5wbg4wtsensdNeGZmTqz8h03zSXvfA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parsing/-/parsing-2.1.0.tgz",
+      "integrity": "sha512-hSV37eE9NZnid7Kc5S01aoXH6Cg8TpATVrsXBZ9PdpY96lrb6iFsxm5axtLrhQKp0e1FxiKH6PNi8YWjahPm7Q==",
       "dev": true,
       "requires": {
-        "microdash": "^1.0.0"
+        "microdash": "^1.4.0"
       }
     },
     "path-exists": {
@@ -1198,24 +1198,24 @@
       }
     },
     "phptoast": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/phptoast/-/phptoast-7.1.0.tgz",
-      "integrity": "sha512-sdC7y+f0CzXGt6PgKm3bOPD/7FDI8bNi5U9HbjaPOKacPA7edfX3FGgd47Ul2Q+QOo7CqpsKB/fMxO3Da8KOXw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/phptoast/-/phptoast-8.0.0.tgz",
+      "integrity": "sha512-cYOp7gi/SvpAhoGQtMyG3MAM/A8DeNk3wh2KztqvYl377yWEyn3tzSRpARVLOQvFH6Jlr+BFgJVhZjnSWon6LQ==",
       "dev": true,
       "requires": {
-        "microdash": "~1",
-        "parsing": "^2.0.0",
+        "microdash": "^1.4.1",
+        "parsing": "^2.1.0",
         "phpcommon": "^2.0.0"
       }
     },
     "phptojs": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/phptojs/-/phptojs-7.2.0.tgz",
-      "integrity": "sha512-UgA0PyKqhcjC4t+an2Fx0aJP7BSCyHds0DyckXfOYnzxj3LWQmXGBJ5cM6m8c6/1wjqos/sUjaAtzo16BUjufg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/phptojs/-/phptojs-8.0.0.tgz",
+      "integrity": "sha512-522oG2N5TnM9DmtAbxksu08WZF+yJpewrYLPJ9Z4J/KQKb8I9ZdqZ5dEgLzlpO5VJveBDxyGqyTCKvqzl3+ufg==",
       "dev": true,
       "requires": {
         "es6-set": "^0.1.5",
-        "microdash": "~1",
+        "microdash": "^1.4.1",
         "phpcommon": "^2.0.0",
         "source-map": "^0.5.6",
         "source-map-to-comment": "^1.1.0",
@@ -1366,28 +1366,6 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
-      }
-    },
-    "string.prototype.trimleft": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimstart": "^1.0.0"
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimend": "^1.0.0"
       }
     },
     "string.prototype.trimstart": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -899,9 +899,9 @@
       "dev": true
     },
     "microdash": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/microdash/-/microdash-1.4.1.tgz",
-      "integrity": "sha512-NJz1FkkTucluPbIzxkuLutzFTI3WWGJ8iOBAJIO49oHK19YkAOR/q8/XASiYS8J8OK8zGpxSD6/j/+M90gqdsQ=="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/microdash/-/microdash-1.4.2.tgz",
+      "integrity": "sha512-2R0iCltd/G5JKN3yCP9lgCbGLv+KpttUHIBW1Wfm7Mggbh3rsWEktHGsHHAGlGMjCYAvM+yL+eZgNxNGH6z+EQ=="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "es6-weak-map": "^2.0.3",
     "is-promise": "^2.2.2",
     "lie": "^3.0.1",
-    "microdash": "~1",
+    "microdash": "^1.4.1",
     "pausable": "^4.4.2",
     "pauser": "~1",
     "phpcommon": "^2.0.0"
@@ -34,11 +34,11 @@
   "devDependencies": {
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "jshint": "^2.10.2",
-    "mocha": "^7.1.2",
+    "jshint": "^2.12.0",
+    "mocha": "^7.2.0",
     "nowdoc": "^1.0.1",
-    "phptoast": "^7.1.0",
-    "phptojs": "^7.1.0",
+    "phptoast": "^8.0.0",
+    "phptojs": "^8.0.0",
     "sinon": "^5.1.1",
     "sinon-chai": "^3.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "es6-weak-map": "^2.0.3",
     "is-promise": "^2.2.2",
     "lie": "^3.0.1",
-    "microdash": "^1.4.1",
+    "microdash": "^1.4.2",
     "pausable": "^4.4.2",
     "pauser": "~1",
     "phpcommon": "^2.0.0"

--- a/src/Class.js
+++ b/src/Class.js
@@ -300,7 +300,7 @@ module.exports = require('pauser')([
         },
 
         /**
-         * Calls the constructor for the provided object
+         * Calls the userland constructor for the provided object
          *
          * @param {ObjectValue} objectValue
          * @param {Value[]} args
@@ -561,6 +561,23 @@ module.exports = require('pauser')([
          */
         instantiate: function (args) {
             var classObject = this,
+                objectValue = classObject.instantiateBare(args);
+
+            // Call the userland constructor
+            classObject.construct(objectValue, args);
+
+            return objectValue;
+        },
+
+        /**
+         * Creates a new instance of this class without calling any userland constructor
+         * (note that for JS classes the class-constructor-function will still be called)
+         *
+         * @param {Value[]} args
+         * @returns {ObjectValue}
+         */
+        instantiateBare: function (args) {
+            var classObject = this,
                 nativeObject = Object.create(classObject.InternalClass.prototype),
                 objectValue = classObject.valueFactory.createObject(nativeObject, classObject);
 
@@ -570,8 +587,6 @@ module.exports = require('pauser')([
                 objectValue,
                 unwrapArgs(args, classObject)
             );
-
-            classObject.construct(objectValue, args);
 
             return objectValue;
         },

--- a/src/Engine.js
+++ b/src/Engine.js
@@ -180,12 +180,16 @@ _.extend(Engine.prototype, {
         this.environment.defineNonCoercingFunction(name, fn);
     },
 
-    defineSuperGlobal: function (name, nativeValue) {
-        var engine = this,
-            valueFactory = engine.environment.getState().getValueFactory(),
-            value = valueFactory.coerce(nativeValue);
-
-        engine.environment.defineSuperGlobal(name, value);
+    /**
+     * Defines a super global variable (available in all scopes implicitly,
+     * unlike a normal global which is not available unless imported with a `global` statement)
+     * and gives it the provided value. If a native value is given then it will be coerced to a PHP one.
+     *
+     * @param {string} name
+     * @param {Value|*} value
+     */
+    defineSuperGlobal: function (name, value) {
+        this.environment.defineSuperGlobal(name, value);
     },
 
     defineSuperGlobalAccessor: function (name, valueGetter, valueSetter) {

--- a/src/Engine.js
+++ b/src/Engine.js
@@ -431,6 +431,17 @@ _.extend(Engine.prototype, {
         return this.environment.getConstant(name);
     },
 
+    /**
+     * Fetches the value of a global variable, if defined.
+     * If the variable is not defined then a NULL value will be returned.
+     *
+     * @param {string} name
+     * @return {Value}
+     */
+    getGlobal: function (name) {
+        return this.environment.getGlobal(name);
+    },
+
     getStderr: function () {
         return this.environment.getStderr();
     },
@@ -441,6 +452,20 @@ _.extend(Engine.prototype, {
 
     getStdout: function () {
         return this.environment.getStdout();
+    },
+
+    /**
+     * Sets the value of an existing PHP global. If a native value is given
+     * then it will be coerced to a PHP one.
+     * If the global is not defined than an error will be thrown -
+     * use .defineGlobal(...) when defining a new variable
+     *
+     * @param {string} name
+     * @param {Value|*} value
+     * @throws {Error} Throws if the variable is not defined in the global scope
+     */
+    setGlobal: function (name, value) {
+        this.environment.setGlobal(name, value);
     }
 });
 

--- a/src/Environment.js
+++ b/src/Environment.js
@@ -114,6 +114,14 @@ _.extend(Environment.prototype, {
         this.state.defineNonCoercingFunction(name, fn);
     },
 
+    /**
+     * Defines a super global variable (available in all scopes implicitly,
+     * unlike a normal global which is not available unless imported with a `global` statement)
+     * and gives it the provided value. If a native value is given then it will be coerced to a PHP one.
+     *
+     * @param {string} name
+     * @param {Value|*} value
+     */
     defineSuperGlobal: function (name, value) {
         this.state.defineSuperGlobal(name, value);
     },

--- a/src/Environment.js
+++ b/src/Environment.js
@@ -130,6 +130,17 @@ _.extend(Environment.prototype, {
         return this.state.getConstant(name);
     },
 
+    /**
+     * Fetches the value of a global variable, if defined.
+     * If the variable is not defined then a NULL value will be returned.
+     *
+     * @param {string} name
+     * @return {Value}
+     */
+    getGlobal: function (name) {
+        return this.state.getGlobal(name);
+    },
+
     getOptions: function () {
         return this.state.getOptions();
     },
@@ -182,6 +193,20 @@ _.extend(Environment.prototype, {
         } else {
             throw new Error('Invalid error type given');
         }
+    },
+
+    /**
+     * Sets the value of an existing PHP global. If a native value is given
+     * then it will be coerced to a PHP one.
+     * If the global is not defined than an error will be thrown -
+     * use .defineGlobal(...) when defining a new variable
+     *
+     * @param {string} name
+     * @param {Value|*} value
+     * @throws {Error} Throws if the variable is not defined in the global scope
+     */
+    setGlobal: function (name, value) {
+        this.state.setGlobal(name, value);
     }
 });
 

--- a/src/LoadScope.js
+++ b/src/LoadScope.js
@@ -130,10 +130,11 @@ _.extend(LoadScope.prototype, {
     /**
      * Fetches the current file path, taking eval or include into account
      *
+     * @param {string|null} filePath
      * @returns {string|null}
      */
-    getFilePath: function () {
-        return this.callerFilePath;
+    getFilePath: function (filePath) {
+        return filePath !== null ? filePath : this.callerFilePath;
     },
 
     /**

--- a/src/PHPState.js
+++ b/src/PHPState.js
@@ -436,13 +436,16 @@ module.exports = require('pauser')([
                 return state.bindings[bindingName];
             }.bind(this),
             getConstant: getConstant,
+            getGlobal: this.getGlobal.bind(this),
             globalNamespace: globalNamespace,
+            globalScope: globalScope,
             iniState: this.iniState,
             mode: mode,
             optionSet: this.optionSet,
             output: this.output,
             pausable: pausable,
             runtime: runtime,
+            setGlobal: this.setGlobal.bind(this),
             stdout: stdout,
             traceFormatter: traceFormatter,
             translator: translator,
@@ -632,13 +635,24 @@ module.exports = require('pauser')([
         },
 
         /**
-         * Defines a global variable and gives it the provided value
+         * Defines a global variable and gives it the provided value,
+         * if not already defined. If the variable is already defined
+         * in this scope then an error will be thrown
          *
          * @param {string} name
-         * @param {Value} value
+         * @param {Value|*} value Value object or native value to be coerced
+         * @throws {Error} Throws when the global scope already defines the specified variable
          */
         defineGlobal: function (name, value) {
-            this.globalScope.defineVariable(name).setValue(value);
+            var state = this;
+
+            if (state.globalScope.hasVariable(name)) {
+                throw new Error(
+                    'PHPState.defineGlobal() :: Variable "' + name + '" is already defined in the global scope'
+                );
+            }
+
+            state.globalScope.defineVariable(name).setValue(state.valueFactory.coerce(value));
         },
 
         /**
@@ -751,6 +765,17 @@ module.exports = require('pauser')([
             return parsed.namespace.getFunction(parsed.name);
         },
 
+        /**
+         * Fetches the value of a global variable, if defined.
+         * If the variable is not defined then a NULL value will be returned.
+         *
+         * @param {string} name
+         * @return {Value}
+         */
+        getGlobal: function (name) {
+            return this.globalScope.getVariable(name).getValueOrNull();
+        },
+
         getGlobalNamespace: function () {
             return this.globalNamespace;
         },
@@ -840,6 +865,28 @@ module.exports = require('pauser')([
 
         getValueFactory: function () {
             return this.valueFactory;
+        },
+
+        /**
+         * Sets the value of an existing PHP global. If a native value is given
+         * then it will be coerced to a PHP one.
+         * If the global is not defined than an error will be thrown -
+         * use .defineGlobal(...) when defining a new variable
+         *
+         * @param {string} name
+         * @param {Value|*} value Value object or native value to be coerced
+         * @throws {Error} Throws if the variable is not defined in the global scope
+         */
+        setGlobal: function (name, value) {
+            var state = this;
+
+            if (!state.globalScope.hasVariable(name)) {
+                throw new Error(
+                    'PHPState.setGlobal() :: Variable "' + name + '" is not defined in the global scope'
+                );
+            }
+
+            state.globalScope.getVariable(name).setValue(state.valueFactory.coerce(value));
         }
     });
 

--- a/src/PHPState.js
+++ b/src/PHPState.js
@@ -122,7 +122,7 @@ module.exports = require('pauser')([
             var globalNamespace = state.globalNamespace;
 
             /**
-             * Bindings allow components of a plugin to share data.
+             * Bindings allow components of an addon to share data.
              *
              * @param {Function} groupFactory
              */
@@ -254,8 +254,8 @@ module.exports = require('pauser')([
             _.each(installedBuiltinTypes.constantGroups, installConstantGroup);
             _.each(installedBuiltinTypes.defaultINIGroups, installDefaultINIOptionGroup);
             _.each(installedBuiltinTypes.bindingGroups, installBindingGroup);
-            // TODO: Add "exposures" for plugins to expose things to transpiled code
-            // TODO: Add "externals" for plugins to expose things to external code (eg. engine.getExternal(...))?
+            // TODO: Add "exposures" for addons to expose things to transpiled code
+            // TODO: Add "externals" for addons to expose things to external code (eg. engine.getExternal(...))?
             _.each(installedBuiltinTypes.functionGroups, installFunctionGroup);
             _.each(installedBuiltinTypes.classGroups, installClassGroup);
             _.forOwn(installedBuiltinTypes.classes, installClass);
@@ -717,7 +717,7 @@ module.exports = require('pauser')([
         },
 
         /**
-         * Fetches the specified binding from an installed plugin
+         * Fetches the specified binding from an installed addon
          *
          * @param {string} bindingName
          * @returns {*}

--- a/src/PHPState.js
+++ b/src/PHPState.js
@@ -504,7 +504,7 @@ module.exports = require('pauser')([
                      * Calls the constructor for the superclass of this class, if this class extends another
                      *
                      * @param {ObjectValue|object} instance Unwrapped or wrapped instance (see below)
-                     * @param {Value[]} args Arguments
+                     * @param {Value[]|*[]} args Arguments (Value objects if non-coercing, native if coercing)
                      */
                     callSuperConstructor: function (instance, args) {
                         var argValues,

--- a/src/PHPState.js
+++ b/src/PHPState.js
@@ -689,13 +689,17 @@ module.exports = require('pauser')([
         /**
          * Defines a super global variable (available in all scopes implicitly,
          * unlike a normal global which is not available unless imported with a `global` statement)
-         * and gives it the provided value
+         * and gives it the provided value. If a native value is given then it will be coerced to a PHP one.
          *
          * @param {string} name
-         * @param {Value} value
+         * @param {Value|*} value
          */
         defineSuperGlobal: function (name, value) {
-            this.superGlobalScope.defineVariable(name).setValue(value);
+            var state = this;
+
+            state.superGlobalScope
+                .defineVariable(name)
+                .setValue(state.valueFactory.coerce(value));
         },
 
         /**

--- a/src/Reference/Element.js
+++ b/src/Reference/Element.js
@@ -34,12 +34,6 @@ function ElementReference(valueFactory, callStack, arrayValue, key, value, refer
 util.inherits(ElementReference, Reference);
 
 _.extend(ElementReference.prototype, {
-    clone: function () {
-        var element = this;
-
-        return new ElementReference(element.valueFactory, element.callStack, element.arrayValue, element.key, element.value);
-    },
-
     getKey: function () {
         return this.key;
     },
@@ -52,8 +46,9 @@ _.extend(ElementReference.prototype, {
      *
      * @param {Value|undefined} overrideKey Optional key to use rather than this element's
      * @returns {KeyReferencePair|KeyValuePair}
+     * @throws {Error} Throws when the element is neither defined as a reference nor with a value
      */
-    getPair: function (overrideKey) {
+    getPairForAssignment: function (overrideKey) {
         var element = this;
 
         if (!overrideKey) {
@@ -61,7 +56,7 @@ _.extend(ElementReference.prototype, {
         }
 
         if (element.value) {
-            return new KeyValuePair(overrideKey, element.value);
+            return new KeyValuePair(overrideKey, element.value.getForAssignment());
         }
 
         if (element.reference) {

--- a/src/Reference/Element/HookableElement.js
+++ b/src/Reference/Element/HookableElement.js
@@ -35,17 +35,6 @@ util.inherits(HookableElementReference, Reference);
 
 _.extend(HookableElementReference.prototype, {
     /**
-     * Creates a copy of this reference
-     *
-     * @returns {HookableElementReference}
-     */
-    clone: function () {
-        var element = this;
-
-        return new HookableElementReference(element.decoratedElement, element.elementHookCollection);
-    },
-
-    /**
      * Fetches an instance property of this element (assuming it contains an object) by its name
      *
      * @param {string} name
@@ -73,8 +62,8 @@ _.extend(HookableElementReference.prototype, {
      * @param {Value|undefined} overrideKey Optional key to use rather than this element's
      * @returns {KeyReferencePair|KeyValuePair}
      */
-    getPair: function (overrideKey) {
-        return this.decoratedElement.getPair(overrideKey);
+    getPairForAssignment: function (overrideKey) {
+        return this.decoratedElement.getPairForAssignment(overrideKey);
     },
 
     /**

--- a/src/Reference/Property.js
+++ b/src/Reference/Property.js
@@ -74,25 +74,6 @@ util.inherits(PropertyReference, Reference);
 
 _.extend(PropertyReference.prototype, {
     /**
-     * Makes a copy of this property
-     *
-     * @returns {PropertyReference}
-     */
-    clone: function () {
-        var property = this;
-
-        return new PropertyReference(
-            property.valueFactory,
-            property.callStack,
-            property.objectValue,
-            property.key,
-            property.classObject,
-            property.visibility,
-            property.index
-        );
-    },
-
-    /**
      * Fetches the unique name of this property as viewed from outside the class (eg. when casting to array)
      *
      * @returns {*}

--- a/src/Runtime.js
+++ b/src/Runtime.js
@@ -230,10 +230,10 @@ module.exports = require('pauser')([
          * available in another outside the use of includes.
          *
          * @param {object} options
-         * @param {Array=} plugins
+         * @param {Array=} addons
          * @returns {Environment}
          */
-        createEnvironment: function (options, plugins) {
+        createEnvironment: function (options, addons) {
             var runtime = this,
                 allBuiltins = _.extend({}, runtime.builtins),
                 allOptionGroups = runtime.optionGroups,
@@ -242,20 +242,20 @@ module.exports = require('pauser')([
                 stderr = new Stream(),
                 state;
 
-            _.each(plugins, function (plugin) {
-                if (typeof plugin === 'function') {
-                    // Allow a plugin to be defined as a function, to allow testing
-                    plugin = plugin();
+            _.each(addons, function (addon) {
+                if (typeof addon === 'function') {
+                    // Allow an addon to be defined as a function, to allow testing
+                    addon = addon();
                 }
 
-                allBuiltins.translationCatalogues = allBuiltins.translationCatalogues.concat(plugin.translationCatalogues || []);
-                allBuiltins.functionGroups = allBuiltins.functionGroups.concat(plugin.functionGroups || []);
-                allBuiltins.classGroups = allBuiltins.classGroups.concat(plugin.classGroups || []);
-                allBuiltins.classes = _.extend({}, allBuiltins.classes, plugin.classes);
-                allBuiltins.constantGroups = allBuiltins.constantGroups.concat(plugin.constantGroups || []);
-                allBuiltins.defaultINIGroups = allBuiltins.defaultINIGroups.concat(plugin.defaultINIGroups || []);
-                allOptionGroups = allOptionGroups.concat(plugin.optionGroups || []);
-                allBuiltins.bindingGroups = allBuiltins.bindingGroups.concat(plugin.bindingGroups || []);
+                allBuiltins.translationCatalogues = allBuiltins.translationCatalogues.concat(addon.translationCatalogues || []);
+                allBuiltins.functionGroups = allBuiltins.functionGroups.concat(addon.functionGroups || []);
+                allBuiltins.classGroups = allBuiltins.classGroups.concat(addon.classGroups || []);
+                allBuiltins.classes = _.extend({}, allBuiltins.classes, addon.classes);
+                allBuiltins.constantGroups = allBuiltins.constantGroups.concat(addon.constantGroups || []);
+                allBuiltins.defaultINIGroups = allBuiltins.defaultINIGroups.concat(addon.defaultINIGroups || []);
+                allOptionGroups = allOptionGroups.concat(addon.optionGroups || []);
+                allBuiltins.bindingGroups = allBuiltins.bindingGroups.concat(addon.bindingGroups || []);
             });
 
             state = new runtime.PHPState(
@@ -285,7 +285,7 @@ module.exports = require('pauser')([
             var builtins = this.builtins;
 
             if (typeof newBuiltins === 'function') {
-                // Allow a plugin to be defined as a function, to allow testing
+                // Allow an addon to be defined as a function, to allow testing
                 newBuiltins = newBuiltins();
             }
 

--- a/src/Scope.js
+++ b/src/Scope.js
@@ -125,14 +125,23 @@ module.exports = require('pauser')([
         },
 
         /**
-         * Defines a variable with the given name in this scope
+         * Defines a variable with the given name in this scope. If it is already defined,
+         * in this scope (not including the superglobal scope) then an error will be thrown
          *
          * @param {string} name
          * @returns {Variable}
+         * @throws {Error} Throws when the variable is already defined in this scope
          */
         defineVariable: function (name) {
             var scope = this,
-                variable = scope.variableFactory.createVariable(name);
+                variable;
+
+            if (hasOwn.call(scope.variables, name)) {
+                // Variable is already defined, just return
+                throw new Error('Variable "' + name + '" is already defined in this scope');
+            }
+
+            variable = scope.variableFactory.createVariable(name);
 
             scope.variables[name] = variable;
 
@@ -379,6 +388,17 @@ module.exports = require('pauser')([
             }
 
             return variable;
+        },
+
+        /**
+         * Determines whether this scope defines the specified variable or not
+         * (not including the superglobal scope)
+         *
+         * @param {string} name
+         * @returns {boolean}
+         */
+        hasVariable: function (name) {
+            return hasOwn.call(this.variables, name);
         },
 
         /**

--- a/src/Value.js
+++ b/src/Value.js
@@ -21,6 +21,7 @@ module.exports = require('pauser')([
     var PHPError = phpCommon.PHPError,
 
         CLASS_NAME_NOT_VALID = 'core.class_name_not_valid',
+        METHOD_CALLED_ON_NON_OBJECT = 'core.method_called_on_non_object',
         NON_OBJECT_METHOD_CALL = 'core.non_object_method_call',
         UNSUPPORTED_OPERAND_TYPES = 'core.unsupported_operand_types',
 
@@ -120,6 +121,17 @@ module.exports = require('pauser')([
          */
         callStaticMethod: function () {
             this.callStack.raiseTranslatedError(PHPError.E_ERROR, CLASS_NAME_NOT_VALID);
+        },
+
+        /**
+         * Returns a clone of this value, or throws an Error if not supported
+         *
+         * @throws {ObjectValue}
+         */
+        clone: function () {
+            this.callStack.raiseTranslatedError(PHPError.E_ERROR, METHOD_CALLED_ON_NON_OBJECT, {
+                method: '__clone'
+            });
         },
 
         /**

--- a/src/Value/Array.js
+++ b/src/Value/Array.js
@@ -115,7 +115,7 @@ module.exports = require('pauser')([
 
         addToArray: function (leftValue) {
             var rightValue = this,
-                resultArray = leftValue.clone();
+                resultArray = leftValue.getForAssignment();
 
             _.forOwn(rightValue.keysToElements, function (element, key) {
                 if (!hasOwn.call(resultArray.keysToElements, key)) {
@@ -204,25 +204,6 @@ module.exports = require('pauser')([
             );
         },
 
-        clone: function () {
-            var arrayValue = this,
-                orderedElements = [];
-
-            _.each(arrayValue.value, function (element) {
-                if (element.isDefined()) {
-                    orderedElements.push(element.getPair());
-                }
-            });
-
-            return new ArrayValue(
-                arrayValue.factory,
-                arrayValue.callStack,
-                orderedElements,
-                arrayValue.type,
-                arrayValue.elementProvider
-            );
-        },
-
         coerceToArray: function () {
             return this;
         },
@@ -274,8 +255,29 @@ module.exports = require('pauser')([
             return 'Array';
         },
 
+        /**
+         * Fetches a copy of this array, as in PHP arrays are always passed by value
+         * and not by reference
+         *
+         * @return {ArrayValue}
+         */
         getForAssignment: function () {
-            return this.clone();
+            var arrayValue = this,
+                orderedElements = [];
+
+            _.each(arrayValue.value, function (element) {
+                if (element.isDefined()) {
+                    orderedElements.push(element.getPairForAssignment());
+                }
+            });
+
+            return new ArrayValue(
+                arrayValue.factory,
+                arrayValue.callStack,
+                orderedElements,
+                arrayValue.type,
+                arrayValue.elementProvider
+            );
         },
 
         getKeys: function () {
@@ -363,7 +365,7 @@ module.exports = require('pauser')([
          * @returns {KeyValuePair|KeyReferencePair}
          */
         getElementPairByKey: function (key, overrideKey) {
-            return this.getElementByKey(key).getPair(overrideKey);
+            return this.getElementByKey(key).getPairForAssignment(overrideKey);
         },
 
         /**

--- a/src/Variable.js
+++ b/src/Variable.js
@@ -247,50 +247,70 @@ module.exports = require('pauser')([
             variable.setValue(variable.getValue().multiply(rightValue));
         },
 
+        /**
+         * Decrements the stored value, returning its original value
+         *
+         * @returns {Value}
+         */
         postDecrement: function () {
             var variable = this,
-                decrementedValue = variable.value.decrement(),
-                result = variable.value;
+                decrementedValue = variable.getValue().decrement(),
+                result = variable.getValue();
 
             if (decrementedValue) {
-                variable.value = decrementedValue;
+                variable.setValue(decrementedValue);
             }
 
             return result;
         },
 
+        /**
+         * Decrements the stored value, returning its new value
+         *
+         * @returns {Value}
+         */
         preDecrement: function () {
             var variable = this,
-                decrementedValue = variable.value.decrement();
+                decrementedValue = variable.getValue().decrement();
 
             if (decrementedValue) {
-                variable.value = decrementedValue;
+                variable.setValue(decrementedValue);
             }
 
-            return variable.value;
+            return variable.getValue();
         },
 
+        /**
+         * Increments the stored value, returning its original value
+         *
+         * @returns {Value}
+         */
         postIncrement: function () {
             var variable = this,
-                incrementedValue = variable.value.increment(),
-                result = variable.value;
+                incrementedValue = variable.getValue().increment(),
+                result = variable.getValue();
 
             if (incrementedValue) {
-                variable.value = incrementedValue;
+                variable.setValue(incrementedValue);
             }
 
             return result;
         },
 
+        /**
+         * Increments the stored value, returning its new value
+         *
+         * @returns {Value}
+         */
         preIncrement: function () {
             var variable = this,
-                incrementedValue = variable.value.increment();
+                incrementedValue = variable.getValue().increment();
 
             if (incrementedValue) {
-                variable.value = incrementedValue;
+                variable.setValue(incrementedValue);
             }
 
-            return variable.value;
+            return variable.getValue();
         },
 
         /**

--- a/src/builtin/interfaces/Iterator.js
+++ b/src/builtin/interfaces/Iterator.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-module.exports = function () {
+module.exports = function (internals) {
     /**
      * Interface for user-defined iterators or objects that can be iterated themselves internally
      *
@@ -21,9 +21,7 @@ module.exports = function () {
 
     }
 
-    // TODO: Unify the way super class and interface references work -
-    //       .superClass takes a Class instance while .interfaces takes strings
-    Iterator.interfaces = ['Traversable'];
+    internals.implement('Traversable');
 
     Iterator.shadowConstructor = function () {
         var iteratorValue = this;

--- a/src/builtin/interfaces/IteratorAggregate.js
+++ b/src/builtin/interfaces/IteratorAggregate.js
@@ -9,7 +9,7 @@
 
 'use strict';
 
-module.exports = function () {
+module.exports = function (internals) {
     /**
      * Interface for user-defined iterators or objects that can be iterated themselves internally
      *
@@ -21,9 +21,7 @@ module.exports = function () {
 
     }
 
-    // TODO: Unify the way super class and interface references work -
-    //       .superClass takes a Class instance while .interfaces takes strings
-    IteratorAggregate.interfaces = ['Traversable'];
+    internals.implement('Traversable');
 
     IteratorAggregate.shadowConstructor = function () {
         var aggregateValue = this;

--- a/src/builtin/messages/error.en_GB.js
+++ b/src/builtin/messages/error.en_GB.js
@@ -30,6 +30,7 @@ module.exports = {
             'class_not_found': 'Class \'${name}\' not found',
             'function_name_must_be_string': 'Function name must be a string',
             'invalid_value_for_type': 'Argument ${index} passed to ${func}() must be ${expectedType}, ${actualType} given, called in ${callerFile} on line ${callerLine} and defined in ${definitionFile}:${definitionLine}',
+            'method_called_on_non_object': '${method} method called on non-object',
             'no_parent_class': 'Cannot access parent:: when current class scope has no parent',
             'non_object_method_call': 'Call to a member function ${name}() on ${type}',
             'object_from_get_iterator_must_be_traversable': 'Objects returned by ${className}::getIterator() must be traversable or implement interface Iterator',

--- a/test/integration/addonTest.js
+++ b/test/integration/addonTest.js
@@ -13,14 +13,14 @@ var expect = require('chai').expect,
     nowdoc = require('nowdoc'),
     tools = require('./tools');
 
-describe('Custom plugin integration', function () {
+describe('Custom addon integration', function () {
     var runtime;
 
     beforeEach(function () {
         runtime = tools.createSyncRuntime();
     });
 
-    it('should support installing a plugin with a binding', function () {
+    it('should support installing an addon with a binding', function () {
         var php = nowdoc(function () {/*<<<EOS
 <?php
 return get_my_value();
@@ -58,7 +58,7 @@ EOS
         expect(engine.execute().getNative()).to.equal(21);
     });
 
-    it('should support installing a plugin with custom syntax', function () {
+    it('should support installing an addon with custom syntax', function () {
         var php = nowdoc(function () {/*<<<EOS
 <?php
 
@@ -98,7 +98,7 @@ EOS
         expect(engine.getStdout().readAll()).to.equal('Logged: 242');
     });
 
-    describe('when installing a plugin into an environment (rather than into the entire runtime)', function () {
+    describe('when installing an addon into an environment (rather than into the entire runtime)', function () {
         var environment,
             module;
 
@@ -139,13 +139,13 @@ EOS
             module = tools.transpile(runtime, null, php);
         });
 
-        it('should correctly install the plugin', function () {
+        it('should correctly install the addon', function () {
             var engine = module({}, environment);
 
             expect(engine.execute().getNative()).to.equal(42);
         });
 
-        it('should keep the plugin isolated to the environment', function () {
+        it('should keep the addon isolated to the environment', function () {
             var module2;
             module({}, environment).execute();
             module2 = tools.transpile(runtime, null, '<?php return function_exists("double_it");');

--- a/test/integration/classes/autoCoercionTest.js
+++ b/test/integration/classes/autoCoercionTest.js
@@ -1,0 +1,270 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    nowdoc = require('nowdoc'),
+    tools = require('../tools');
+
+describe('PHP class auto-coercion integration', function () {
+    it('should correctly handle a single auto-coercing class', function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+$myObject = new MyClass(1001, 'my string');
+
+$result = [];
+$result[] = $myObject->multiplyNumberBy(2);
+$result[] = $myObject->getString();
+
+return $result;
+EOS
+*/;}), //jshint ignore:line
+            module = tools.syncTranspile(null, php),
+            engine = module();
+
+        engine.defineClass('MyClass', function () {
+            function MyClass(myNumber, myString) {
+                this.myNumber = myNumber;
+                this.myString = myString;
+            }
+
+            MyClass.prototype.getString = function () {
+                return this.myString;
+            };
+
+            MyClass.prototype.multiplyNumberBy = function (myMultiplier) {
+                return this.myNumber * myMultiplier;
+            };
+
+            return MyClass;
+        });
+
+        expect(engine.execute().getNative()).to.deep.equal([
+            2002,
+            'my string'
+        ]);
+        expect(engine.getStderr().readAll()).to.equal('');
+    });
+
+    it('should correctly handle passing instances of an auto-coercing class to another', function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+$concatenator = new Concatenator(', and: ');
+$stringA = new StringEncapsulator('my first string');
+$stringB = new StringEncapsulator('my second string');
+
+$result = [];
+$result[] = $concatenator->concatenate($stringA, $stringB);
+
+return $result;
+EOS
+*/;}), //jshint ignore:line
+            module = tools.syncTranspile(null, php),
+            engine = module();
+
+        engine.defineClass('StringEncapsulator', function () {
+            function StringEncapsulator(myString) {
+                this.myString = myString;
+            }
+
+            StringEncapsulator.prototype.getString = function () {
+                return this.myString;
+            };
+
+            return StringEncapsulator;
+        });
+
+        engine.defineClass('Concatenator', function () {
+            function Concatenator(delimiter) {
+                this.delimiter = delimiter;
+            }
+
+            Concatenator.prototype.concatenate = function (encapsulatedStringA, encapsulatedStringB) {
+                return [encapsulatedStringA.getString(), encapsulatedStringB.getString()].join(this.delimiter);
+            };
+
+            return Concatenator;
+        });
+
+        expect(engine.execute().getNative()).to.deep.equal([
+            'my first string, and: my second string'
+        ]);
+        expect(engine.getStderr().readAll()).to.equal('');
+    });
+
+    it('should make the underlying native object of an auto-coercing class exposed to JS-land extend the native class', function () {
+        function MyClass(myArg) {
+            this.myArg = myArg;
+        }
+
+        MyClass.prototype.appendSomething = function (what) {
+            this.myArg += ' ' + what;
+        };
+
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+$myObject = new MyClass('my value');
+$myObject->appendSomething('[from PHP]');
+
+return $myObject;
+EOS
+*/;}), //jshint ignore:line
+            module = tools.syncTranspile(null, php),
+            engine = module(),
+            nativeObject;
+        engine.defineClass('MyClass', function (/* internals */) {
+            // TODO: Support this (see below)
+            // internals.exposeProperty('myArg');
+
+            return MyClass;
+        });
+
+        nativeObject = engine.execute().getNative();
+        nativeObject.appendSomething('[from JS]');
+
+        expect(nativeObject).to.be.an.instanceOf(MyClass);
+        // TODO: Implement internals.exposeProperty(...) to allow the below
+        // expect(nativeObject.myArg).to.equal('my value [from PHP] [from JS]');
+        expect(engine.getStderr().readAll()).to.equal('');
+    });
+
+    it('should always treat the exposed native object of an auto-coercing class as identical to itself', function () {
+        function MyClass(myArg) {
+            this.myArg = myArg;
+        }
+
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+$myObject = new MyClass('my value');
+
+return [
+    'strictlyCompare' => function ($object1, $object2) {
+        return $object1 === $object2;
+    },
+    'myObject' => $myObject
+];
+EOS
+*/;}), //jshint ignore:line
+            module = tools.syncTranspile(null, php),
+            engine = module(),
+            result;
+        engine.defineClass('MyClass', function () {
+            return MyClass;
+        });
+
+        result = engine.execute().getNative();
+
+        /*
+        // Pass the unwrapped auto-coercing class' instance back twice, where we will
+        // perform a strict PHP comparison, to ensure the exposed native object is always
+        // considered identical to itself.
+        // Ideally we would be checking that it is always mapped back to the same ObjectValue
+        // instance to ensure we don't waste memory, but that cannot be tested from here
+        // as the identity check is done on the native object anyway.
+         */
+        expect(result.strictlyCompare(result.myObject, result.myObject)).to.be.true;
+        expect(engine.getStderr().readAll()).to.equal('');
+    });
+
+    it('should support an auto-coercing class extending another', function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+$myObject = new MyChildClass('[from PHP]');
+
+$result = [];
+$result[] = $myObject->getString();
+
+return $result;
+EOS
+*/;}), //jshint ignore:line
+            module = tools.syncTranspile(null, php),
+            engine = module();
+
+        engine.defineClass('MyParentClass', function () {
+            function MyParentClass(myString) {
+                this.myString = myString + ' [from parent ctor]';
+            }
+
+            return MyParentClass;
+        });
+        engine.defineClass('MyChildClass', function (internals) {
+            function MyChildClass(myString) {
+                internals.callSuperConstructor(this, [myString + ' [from child ctor]']);
+            }
+
+            internals.extendClass('MyParentClass');
+
+            MyChildClass.prototype.getString = function () {
+                return this.myString;
+            };
+
+            return MyChildClass;
+        });
+
+        expect(engine.execute().getNative()).to.deep.equal([
+            '[from PHP] [from child ctor] [from parent ctor]'
+        ]);
+        expect(engine.getStderr().readAll()).to.equal('');
+    });
+
+    it('should support an auto-coercing class extending a non-coercing class', function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+$myObject = new MyChildClass('[from PHP]');
+
+$result = [];
+$result[] = $myObject->getString();
+
+return $result;
+EOS
+*/;}), //jshint ignore:line
+            module = tools.syncTranspile(null, php),
+            engine = module();
+
+        engine.defineClass('MyParentClass', function (internals) {
+            function MyParentClass(myStringReference) {
+                this.setProperty(
+                    'myString',
+                    myStringReference.getValue().concat(
+                        internals.valueFactory.createString(' [from parent ctor]')
+                    )
+                );
+            }
+
+            internals.disableAutoCoercion();
+
+            return MyParentClass;
+        });
+        engine.defineClass('MyChildClass', function (internals) {
+            function MyChildClass(myString) {
+                internals.callSuperConstructor(this, [myString + ' [from child ctor]']);
+            }
+
+            internals.extendClass('MyParentClass');
+
+            MyChildClass.prototype.getString = function () {
+                return this.myString;
+            };
+
+            return MyChildClass;
+        });
+
+        expect(engine.execute().getNative()).to.deep.equal([
+            '[from PHP] [from child ctor] [from parent ctor]'
+        ]);
+        expect(engine.getStderr().readAll()).to.equal('');
+    });
+});

--- a/test/integration/constructs/namespaceTest.js
+++ b/test/integration/constructs/namespaceTest.js
@@ -1,0 +1,56 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    nowdoc = require('nowdoc'),
+    tools = require('../tools');
+
+describe('PHP namespace (backslash-delimited) construct integration', function () {
+    it('should allow the special namespace keyword to resolve to the current namespace, regardless of "use" imports', function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+namespace Your\Stuff {
+    class SomeClass {
+        const SOME_THING = 'your thing!';
+    }
+}
+
+namespace My\Stuff {
+    class SomeClass {
+        const SOME_THING = 'my thing!';
+    }
+}
+
+// In a new namespace scope
+namespace My {
+    use Your\Stuff;
+
+    $result = [];
+    $result['taking use statements into account'] = Stuff\SomeClass::SOME_THING;
+    $result['explicitly current namespace-relative'] = namespace\Stuff\SomeClass::SOME_THING;
+    $result['explicitly current namespace-relative, mixed case keyword'] = naMEsPaCe\Stuff\SomeClass::SOME_THING;
+
+    return $result;
+}
+
+EOS
+*/;}), //jshint ignore:line
+            module = tools.syncTranspile('/path/to/my_module.php', php),
+            engine = module();
+
+        expect(engine.execute().getNative()).to.deep.equal({
+            'taking use statements into account': 'your thing!',
+            'explicitly current namespace-relative': 'my thing!',
+            'explicitly current namespace-relative, mixed case keyword': 'my thing!'
+        });
+        expect(engine.getStderr().readAll()).to.equal('');
+    });
+});

--- a/test/integration/operators/assignmentTest.js
+++ b/test/integration/operators/assignmentTest.js
@@ -89,4 +89,34 @@ EOS
             }
         ]);
     });
+
+    it('should recursively copy arrays for assignment (shallow copy, except for nested arrays, unless references)', function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+$result = [];
+
+$firstArray = [21];
+$secondArray = [$firstArray];
+$thirdArray = [&$firstArray];
+
+// $thirdArray _should_ be affected as $firstArray was embedded by reference
+$firstArray[] = 'I should not affect $secondArray';
+
+$result['firstArray'] = $firstArray;
+$result['secondArray'] = $secondArray;
+$result['thirdArray'] = $thirdArray;
+
+return $result;
+EOS
+*/;}), //jshint ignore:line
+            module = tools.syncTranspile(null, php),
+            engine = module();
+
+        expect(engine.execute().getNative()).to.deep.equal({
+            firstArray: [21, 'I should not affect $secondArray'],
+            secondArray: [[21]],
+            thirdArray: [[21, 'I should not affect $secondArray']]
+        });
+    });
 });

--- a/test/integration/operators/cloneTest.js
+++ b/test/integration/operators/cloneTest.js
@@ -1,0 +1,306 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    nowdoc = require('nowdoc'),
+    tools = require('../tools');
+
+describe('PHP clone operator integration', function () {
+    it('should support cloning a stdClass instance', function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+$original = new stdClass;
+$original->prop1 = ['one'];
+$original->prop2 = 'two';
+
+$clone = clone $original;
+
+$result = [];
+
+// Before modification
+$result['identity'] = $clone === $original;
+$result['original prop1, first'] = $original->prop1;
+$result['original prop2, first'] = $original->prop2;
+$result['clone prop1, first'] = $clone->prop1;
+$result['clone prop2, first'] = $clone->prop2;
+
+// After modification
+$clone->prop1[] = 'extra';
+$clone->prop2 = 'two, but modified';
+
+$result['original prop1, second'] = $original->prop1;
+$result['original prop2, second'] = $original->prop2; // Should not be modified
+$result['clone prop1, second'] = $clone->prop1;
+$result['clone prop2, second'] = $clone->prop2;
+
+return $result;
+EOS
+*/;}), //jshint ignore:line
+            module = tools.syncTranspile(null, php),
+            engine = module();
+
+        expect(engine.execute().getNative()).to.deep.equal({
+            'identity': false, // Clone should be a different object instance,
+            'original prop1, first': ['one'],
+            'original prop2, first': 'two',
+            'clone prop1, first': ['one'],
+            'clone prop2, first': 'two',
+
+            'original prop1, second': ['one'], // Should not be modified
+            'original prop2, second': 'two',   // Should not be modified
+            'clone prop1, second': ['one', 'extra'],
+            'clone prop2, second': 'two, but modified'
+        });
+    });
+
+    it('should support cloning an instance of a custom class implementing __clone', function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+$counter = 1;
+
+class MyClass {
+    public $prop1;
+    public $prop2;
+    public $prop3;
+
+    public function __construct() {
+        global $counter;
+
+        $this->prop3 = 'set by constructor: ' . ($counter++);
+    }
+
+    public function __clone() {
+        $this->prop2 .= ', modified by __clone';
+    }
+}
+
+$original = new MyClass;
+$original->prop1 = 'one';
+$original->prop2 = 'two';
+
+$clone = clone $original;
+
+$result = [];
+
+// Before modification
+$result['identity'] = $clone === $original;
+$result['original prop1, first'] = $original->prop1;
+$result['original prop2, first'] = $original->prop2;
+$result['original prop3, first'] = $original->prop3;
+$result['clone prop1, first'] = $clone->prop1;
+$result['clone prop2, first'] = $clone->prop2;
+$result['clone prop3, first'] = $clone->prop3;
+
+// After modification
+$clone->prop1 = 'one, but modified outside class';
+
+$result['original prop1, second'] = $original->prop1;
+$result['original prop2, second'] = $original->prop2; // Should not be modified
+$result['original prop3, second'] = $original->prop3;
+$result['clone prop1, second'] = $clone->prop1;
+$result['clone prop2, second'] = $clone->prop2;
+$result['clone prop3, second'] = $clone->prop3;
+
+return $result;
+EOS
+*/;}), //jshint ignore:line
+            module = tools.syncTranspile(null, php),
+            engine = module();
+
+        expect(engine.execute().getNative()).to.deep.equal({
+            'identity': false, // Clone should be a different object instance,
+            'original prop1, first': 'one',
+            'original prop2, first': 'two',
+            'original prop3, first': 'set by constructor: 1',
+            'clone prop1, first': 'one',
+            'clone prop2, first': 'two, modified by __clone',
+            'clone prop3, first': 'set by constructor: 1', // Constructor should not be re-called for clone
+
+            'original prop1, second': 'one',
+            'original prop2, second': 'two', // Should not be modified
+            'original prop3, second': 'set by constructor: 1',
+            'clone prop1, second': 'one, but modified outside class',
+            'clone prop2, second': 'two, modified by __clone',
+            'clone prop3, second': 'set by constructor: 1'
+        });
+    });
+
+    // Introduced in PHP 7.0.0
+    it('should support accessing a member of a freshly cloned object in a single expression', function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+$original = new stdClass;
+$original->myProp = 'my value';
+
+$result = [];
+
+$result['myProp of clone'] = (clone $original)->myProp;
+
+return $result;
+EOS
+*/;}), //jshint ignore:line
+            module = tools.syncTranspile(null, php),
+            engine = module();
+
+        expect(engine.execute().getNative()).to.deep.equal({
+            'myProp of clone': 'my value'
+        });
+    });
+
+    it('should support cloning an imported JS object', function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+$result = [];
+
+// Initially modify originalObject to check the clone starts from this state
+// and not the initial state in the object literal below
+$originalObject->myProp = 21;
+$result['myMethod() of original'] = $originalObject->myMethod();
+
+$cloneObject = clone $originalObject;
+
+// Modify originalObject - make sure it does not impact the clone
+$originalObject->myProp = 'my modified value - I should not be used!';
+
+$result['myMethod() of clone'] = $cloneObject->myMethod();
+
+$result['is original instanceof JSObject'] = $originalObject instanceof JSObject;
+$result['is clone instanceof JSObject'] = $cloneObject instanceof JSObject;
+
+return $result;
+EOS
+*/;}), //jshint ignore:line
+            module = tools.syncTranspile(null, php),
+            engine = module(),
+            myObject = {
+                myProp: 'initial value',
+                myMethod: function () {
+                    return this.myProp;
+                }
+            };
+        engine.expose(myObject, 'originalObject');
+
+        expect(engine.execute().getNative()).to.deep.equal({
+            'myMethod() of original': 21,
+            'myMethod() of clone': 21,
+            'is original instanceof JSObject': true,
+            'is clone instanceof JSObject': true
+        });
+    });
+
+    it('should raise a fatal error when trying to clone non-objects', function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+ini_set('error_reporting', E_ALL);
+
+$result = [];
+
+try {
+    $dummy = clone [21, 101];
+} catch (Throwable $throwable) {
+    $result['array'] = get_my_object_class($throwable) .
+        ': ' .
+        $throwable->getMessage() .
+        ' @ ' .
+        $throwable->getFile() .
+        ':' .
+        $throwable->getLine();
+}
+
+try {
+    $dummy = clone true;
+} catch (Throwable $throwable) {
+    $result['boolean'] = get_my_object_class($throwable) .
+        ': ' .
+        $throwable->getMessage() .
+        ' @ ' .
+        $throwable->getFile() .
+        ':' .
+        $throwable->getLine();
+}
+
+try {
+    $dummy = clone 1234.5678;
+} catch (Throwable $throwable) {
+    $result['float'] = get_my_object_class($throwable) .
+        ': ' .
+        $throwable->getMessage() .
+        ' @ ' .
+        $throwable->getFile() .
+        ':' .
+        $throwable->getLine();
+}
+
+try {
+    $dummy = clone 4321;
+} catch (Throwable $throwable) {
+    $result['integer'] = get_my_object_class($throwable) .
+        ': ' .
+        $throwable->getMessage() .
+        ' @ ' .
+        $throwable->getFile() .
+        ':' .
+        $throwable->getLine();
+}
+
+try {
+    $dummy = clone null;
+} catch (Throwable $throwable) {
+    $result['null'] = get_my_object_class($throwable) .
+        ': ' .
+        $throwable->getMessage() .
+        ' @ ' .
+        $throwable->getFile() .
+        ':' .
+        $throwable->getLine();
+}
+
+try {
+    $dummy = clone 'my string';
+} catch (Throwable $throwable) {
+    $result['string'] = get_my_object_class($throwable) .
+        ': ' .
+        $throwable->getMessage() .
+        ' @ ' .
+        $throwable->getFile() .
+        ':' .
+        $throwable->getLine();
+}
+
+return $result;
+EOS
+*/;}),//jshint ignore:line
+            module = tools.syncTranspile('/my/php_module.php', php, {
+                // Capture offsets of all nodes for line tracking
+                phpToAST: {captureAllOffsets: true},
+                // Record line numbers for statements/expressions
+                phpToJS: {lineNumbers: true}
+            }),
+            engine = module();
+        engine.defineNonCoercingFunction('get_my_object_class', function (objectValue) {
+            return objectValue.getValue().getClassName();
+        });
+
+        expect(engine.execute().getNative()).to.deep.equal({
+            'array': 'Error: __clone method called on non-object @ /my/php_module.php:7',
+            'boolean': 'Error: __clone method called on non-object @ /my/php_module.php:19',
+            'float': 'Error: __clone method called on non-object @ /my/php_module.php:31',
+            'integer': 'Error: __clone method called on non-object @ /my/php_module.php:43',
+            'null': 'Error: __clone method called on non-object @ /my/php_module.php:55',
+            'string': 'Error: __clone method called on non-object @ /my/php_module.php:67'
+        });
+        expect(engine.getStdout().readAll()).to.equal('');
+        expect(engine.getStderr().readAll()).to.equal('');
+    });
+});

--- a/test/integration/operators/decrementTest.js
+++ b/test/integration/operators/decrementTest.js
@@ -14,6 +14,41 @@ var expect = require('chai').expect,
     tools = require('../tools');
 
 describe('PHP decrement "--" operator integration', function () {
+    it('should be able to decrement a variable or variable reference', function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+$result = [];
+$myNumber = 21;
+$myRef =& $myNumber;
+
+$result['initial number'] = $myNumber;
+$result['initial ref'] = $myRef;
+$result['number post-dec'] = $myNumber--;
+$result['ref post-dec'] = $myRef--;
+$result['number pre-dec'] = --$myNumber;
+$result['ref pre-dec'] = --$myRef;
+$result['final number'] = $myNumber;
+$result['final ref'] = $myRef;
+
+return $result;
+EOS
+*/;}), //jshint ignore:line
+            module = tools.syncTranspile(null, php),
+            engine = module();
+
+        expect(engine.execute().getNative()).to.deep.equal({
+            'initial number': 21,
+            'initial ref': 21,
+            'number post-dec': 21, // Post-decrement won't have been able to update the property yet
+            'ref post-dec': 20,    // The previous post-decrement will have updated the property by now
+            'number pre-dec': 18,
+            'ref pre-dec': 17,
+            'final number': 17,
+            'final ref': 17
+        });
+    });
+
     it('should be able to decrement an instance property', function () {
         var php = nowdoc(function () {/*<<<EOS
 <?php

--- a/test/integration/operators/incrementTest.js
+++ b/test/integration/operators/incrementTest.js
@@ -14,6 +14,41 @@ var expect = require('chai').expect,
     tools = require('../tools');
 
 describe('PHP increment "++" operator integration', function () {
+    it('should be able to increment a variable or variable reference', function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+$result = [];
+$myNumber = 21;
+$myRef =& $myNumber;
+
+$result['initial number'] = $myNumber;
+$result['initial ref'] = $myRef;
+$result['number post-inc'] = $myNumber++;
+$result['ref post-inc'] = $myRef++;
+$result['number pre-inc'] = ++$myNumber;
+$result['ref pre-inc'] = ++$myRef;
+$result['final number'] = $myNumber;
+$result['final ref'] = $myRef;
+
+return $result;
+EOS
+*/;}), //jshint ignore:line
+            module = tools.syncTranspile(null, php),
+            engine = module();
+
+        expect(engine.execute().getNative()).to.deep.equal({
+            'initial number': 21,
+            'initial ref': 21,
+            'number post-inc': 21, // Post-increment won't have been able to update the property yet
+            'ref post-inc': 22,    // The previous post-increment will have updated the property by now
+            'number pre-inc': 24,
+            'ref pre-inc': 25,
+            'final number': 25,
+            'final ref': 25
+        });
+    });
+
     it('should be able to increment an instance property', function () {
         var php = nowdoc(function () {/*<<<EOS
 <?php

--- a/test/integration/operators/logical/andTest.js
+++ b/test/integration/operators/logical/andTest.js
@@ -1,0 +1,64 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    nowdoc = require('nowdoc'),
+    tools = require('../../tools');
+
+describe('PHP logical "and" operator integration', function () {
+    it('should support short-circuit evaluation', function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+function returnTruthy() {
+    global $result;
+
+    $result[] = '[in returnTruthy]';
+
+    return true;
+}
+
+function returnFalsy() {
+    global $result;
+
+    $result[] = '[in returnFalsy]';
+
+    return false;
+}
+
+$result = [];
+
+$result[] = returnFalsy() && returnTruthy();
+$result[] = 'done falsy && truthy';
+
+$result[] = returnTruthy() && returnFalsy();
+$result[] = 'done truthy && falsy';
+
+return $result;
+EOS
+*/;}), //jshint ignore:line
+            module = tools.syncTranspile(null, php),
+            engine = module();
+
+        expect(engine.execute().getNative()).to.deep.equal([
+            // falsy && truthy should short-circuit, not evaluating returnTruthy()
+            '[in returnFalsy]',
+            false,
+            'done falsy && truthy',
+
+            // truthy && falsy should not short-circuit, evaluating both
+            '[in returnTruthy]',
+            '[in returnFalsy]',
+            false,
+            'done truthy && falsy'
+        ]);
+    });
+});

--- a/test/integration/syncIncludeTest.js
+++ b/test/integration/syncIncludeTest.js
@@ -82,11 +82,34 @@ EOS
         });
     });
 
+    it('should normalise the called file\'s path', function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+// Deliberately use the current-dir and parent-dir path symbols to check for normalisation
+$message = include 'my/./path/to/../abc.php';
+
+return $message;
+EOS
+*/;}),//jshint ignore:line
+            module = tools.syncTranspile(null, php),
+            options = {
+                path: 'my/caller.php',
+                include: function (path, promise) {
+                    promise.resolve(tools.syncTranspile(path, '<?php return "Hello from " . __FILE__ . "!";'));
+                }
+            };
+
+        expect(module(options).execute().getNative()).to.equal(
+            // Ensure the symbols are resolved here
+            'Hello from my/path/abc.php!'
+        );
+    });
+
     it('should pass the calling file\'s path to the transport', function () {
         var php = nowdoc(function () {/*<<<EOS
 <?php
-$num = include 'abc.php';
-return $num;
+$message = include 'abc.php';
+return $message;
 EOS
 */;}),//jshint ignore:line
             module = tools.syncTranspile(null, php),

--- a/test/integration/syncIncludeTest.js
+++ b/test/integration/syncIncludeTest.js
@@ -502,4 +502,31 @@ EOS
 
         expect(engine.execute().getNative()).to.equal(131);
     });
+
+    it('should allow the include transport to provide an absolute path when fetched relatively via the "include_path"', function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+// Deliberately use the current-dir and parent-dir path symbols to check for normalisation
+$message = include 'my/relative/path.php';
+
+return $message;
+EOS
+*/;}),//jshint ignore:line
+            module = tools.syncTranspile(null, php),
+            options = {
+                path: 'my/caller.php',
+                include: function (path, promise) {
+                    promise.resolve(
+                        tools.syncTranspile(
+                            '/my/resolved/absolute/path/to_module.php',
+                            '<?php return "Hello from " . __FILE__ . "!";'
+                        )
+                    );
+                }
+            };
+
+        expect(module(options).execute().getNative()).to.equal(
+            'Hello from /my/resolved/absolute/path/to_module.php!'
+        );
+    });
 });

--- a/test/unit/EngineTest.js
+++ b/test/unit/EngineTest.js
@@ -248,4 +248,26 @@ describe('Engine', function () {
             expect(engine.getConstant('A_CONST')).to.equal('my value');
         });
     });
+
+    describe('getGlobal()', function () {
+        it('should return the value of the global from the environment', function () {
+            createEngine();
+            environment.getGlobal.withArgs('myGlobal').returns(valueFactory.createInteger(1234));
+
+            expect(engine.getGlobal('myGlobal').getNative()).to.equal(1234);
+        });
+    });
+
+    describe('setGlobal()', function () {
+        it('should set the value of the global via the environment', function () {
+            var value;
+            createEngine();
+            value = valueFactory.createInteger(1234);
+
+            engine.setGlobal('myGlobal', value);
+
+            expect(environment.setGlobal).to.have.been.calledOnce;
+            expect(environment.setGlobal).to.have.been.calledWith('myGlobal', sinon.match.same(value));
+        });
+    });
 });

--- a/test/unit/EngineTest.js
+++ b/test/unit/EngineTest.js
@@ -223,6 +223,21 @@ describe('Engine', function () {
         });
     });
 
+    describe('defineSuperGlobal()', function () {
+        it('should define the super global on the environment', function () {
+            var value = valueFactory.createInteger(21);
+            createEngine();
+
+            engine.defineSuperGlobal('myGlobal', value);
+
+            expect(environment.defineSuperGlobal).to.have.been.calledOnce;
+            expect(environment.defineSuperGlobal).to.have.been.calledWith(
+                'myGlobal',
+                sinon.match.same(value)
+            );
+        });
+    });
+
     describe('defineSuperGlobalAccessor()', function () {
         it('should define the superglobal on the environment', function () {
             var valueGetter = sinon.stub(),

--- a/test/unit/EnvironmentTest.js
+++ b/test/unit/EnvironmentTest.js
@@ -165,6 +165,7 @@ describe('Environment', function () {
     describe('defineSuperGlobal()', function () {
         it('should define the super global on the state', function () {
             var value = sinon.createStubInstance(Value);
+
             environment.defineSuperGlobal('myGlobal', value);
 
             expect(state.defineSuperGlobal).to.have.been.calledOnce;

--- a/test/unit/EnvironmentTest.js
+++ b/test/unit/EnvironmentTest.js
@@ -20,14 +20,17 @@ var expect = require('chai').expect,
     PHPParseError = phpCommon.PHPParseError,
     PHPState = require('../../src/PHPState').sync(),
     Promise = require('lie'),
-    Value = require('../../src/Value').sync();
+    Value = require('../../src/Value').sync(),
+    ValueFactory = require('../../src/ValueFactory').sync();
 
 describe('Environment', function () {
     var environment,
-        state;
+        state,
+        valueFactory;
 
     beforeEach(function () {
         state = sinon.createStubInstance(PHPState);
+        valueFactory = new ValueFactory();
 
         environment = new Environment(state);
     });
@@ -195,6 +198,14 @@ describe('Environment', function () {
         });
     });
 
+    describe('getGlobal()', function () {
+        it('should return the value of the global from the PHPState', function () {
+            state.getGlobal.withArgs('myGlobal').returns(valueFactory.createInteger(1234));
+
+            expect(environment.getGlobal('myGlobal').getNative()).to.equal(1234);
+        });
+    });
+
     describe('getOptions()', function () {
         it('should return the raw options object from the PHPState', function () {
             var options = {'my-option': 27};
@@ -257,6 +268,17 @@ describe('Environment', function () {
             expect(function () {
                 environment.reportError(new Error('I am not a PHPError'));
             }).to.throw('Invalid error type given');
+        });
+    });
+
+    describe('setGlobal()', function () {
+        it('should set the value of the global via the PHPState', function () {
+            var value = valueFactory.createInteger(1234);
+
+            environment.setGlobal('myGlobal', value);
+
+            expect(state.setGlobal).to.have.been.calledOnce;
+            expect(state.setGlobal).to.have.been.calledWith('myGlobal', sinon.match.same(value));
         });
     });
 });

--- a/test/unit/LoadScopeTest.js
+++ b/test/unit/LoadScopeTest.js
@@ -30,8 +30,12 @@ describe('LoadScope', function () {
     });
 
     describe('getFilePath()', function () {
-        it('should return the caller\'s path', function () {
-            expect(loadScope.getFilePath()).to.equal('/path/to/my/caller.php');
+        it('should return the caller\'s path when the given file path is null', function () {
+            expect(loadScope.getFilePath(null)).to.equal('/path/to/my/caller.php');
+        });
+
+        it('should return the given file path when not null', function () {
+            expect(loadScope.getFilePath('/my/given/caller_path.php')).to.equal('/my/given/caller_path.php');
         });
     });
 

--- a/test/unit/NamespaceScopeTest.js
+++ b/test/unit/NamespaceScopeTest.js
@@ -324,6 +324,30 @@ describe('NamespaceScope', function () {
             expect(result.namespace).to.equal(this.globalNamespace);
             expect(result.name).to.equal('MyClass');
         });
+
+        it('should support resolving a path prefixed with the special namespace keyword to the current namespace only, ignoring any "use" imports', function () {
+            var result,
+                subNamespace = sinon.createStubInstance(Namespace);
+            this.namespace.getDescendant.withArgs('Stuff\\Here').returns(subNamespace);
+            this.scope.use('Some\\Other\\StuffNamespace', 'Stuff');
+
+            result = this.scope.resolveClass('namespace\\Stuff\\Here\\MyClass');
+
+            expect(result.namespace).to.equal(subNamespace);
+            expect(result.name).to.equal('MyClass');
+        });
+
+        it('should support resolving a path prefixed with the special namespace keyword using mixed case to the current namespace only, ignoring any "use" imports', function () {
+            var result,
+                subNamespace = sinon.createStubInstance(Namespace);
+            this.namespace.getDescendant.withArgs('Stuff\\Here').returns(subNamespace);
+            this.scope.use('Some\\Other\\StuffNamespace', 'Stuff');
+
+            result = this.scope.resolveClass('naMESPaCe\\Stuff\\Here\\MyClass');
+
+            expect(result.namespace).to.equal(subNamespace);
+            expect(result.name).to.equal('MyClass');
+        });
     });
 
     describe('use()', function () {

--- a/test/unit/PHPStateTest.js
+++ b/test/unit/PHPStateTest.js
@@ -509,12 +509,26 @@ describe('PHPState', function () {
     });
 
     describe('defineGlobal()', function () {
-        it('should define the global and assign it the given value', function () {
-            var value = valueFactory.createInteger(27);
+        it('should be able to define a global and assign it the given Value object', function () {
+            state.defineGlobal('myGlobal', valueFactory.createInteger(27));
 
-            state.defineGlobal('MY_GLOB', value);
+            expect(state.getGlobalScope().getVariable('myGlobal').getValue().getNative()).to.equal(27);
+        });
 
-            expect(state.getGlobalScope().getVariable('MY_GLOB').getValue().getNative()).to.equal(27);
+        it('should be able to define a global and assign it the given native value', function () {
+            state.defineGlobal('myGlobal', 1001);
+
+            expect(state.getGlobalScope().getVariable('myGlobal').getValue().getNative()).to.equal(1001);
+        });
+
+        it('should throw when the global is already defined', function () {
+            state.defineGlobal('myGlobal', 21);
+
+            expect(function () {
+                state.defineGlobal('myGlobal', 21); // Attempt to redefine
+            }).to.throw(
+                'PHPState.defineGlobal() :: Variable "myGlobal" is already defined in the global scope'
+            );
         });
     });
 
@@ -653,6 +667,20 @@ describe('PHPState', function () {
         });
     });
 
+    describe('getGlobal()', function () {
+        it('should be able to fetch the value of a defined global variable', function () {
+            state.defineGlobal('myGlobal', valueFactory.createInteger(9876));
+
+            expect(state.getGlobal('myGlobal').getNative()).to.equal(9876);
+        });
+
+        it('should return a NULL value for an undefined global variable', function () {
+            var value = state.getGlobal('myUndefinedGlobal');
+
+            expect(value.getType()).to.equal('null');
+        });
+    });
+
     describe('getLoader()', function () {
         it('should return a Loader', function () {
             expect(state.getLoader()).to.be.an.instanceOf(Loader);
@@ -681,6 +709,32 @@ describe('PHPState', function () {
     describe('getTranslator()', function () {
         it('should return the Translator service', function () {
             expect(state.getTranslator()).to.be.an.instanceOf(Translator);
+        });
+    });
+
+    describe('setGlobal()', function () {
+        it('should be able to change the value of a defined variable to a Value object', function () {
+            state.defineGlobal('myGlobal', valueFactory.createInteger(21));
+
+            state.setGlobal('myGlobal', valueFactory.createInteger(1001));
+
+            expect(state.getGlobal('myGlobal').getNative()).to.equal(1001);
+        });
+
+        it('should be able to change the value of a defined variable to a native value', function () {
+            state.defineGlobal('myGlobal', valueFactory.createInteger(21));
+
+            state.setGlobal('myGlobal', 987654);
+
+            expect(state.getGlobal('myGlobal').getNative()).to.equal(987654);
+        });
+
+        it('should throw when the specified variable is not defined', function () {
+            expect(function () {
+                state.setGlobal('myUndefinedGlobal', 987654);
+            }).to.throw(
+                'PHPState.setGlobal() :: Variable "myUndefinedGlobal" is not defined in the global scope'
+            );
         });
     });
 });

--- a/test/unit/PHPStateTest.js
+++ b/test/unit/PHPStateTest.js
@@ -597,12 +597,16 @@ describe('PHPState', function () {
     });
 
     describe('defineSuperGlobal()', function () {
-        it('should define the superglobal and assign it the given value', function () {
-            var value = valueFactory.createInteger(101);
+        it('should be able to define a superglobal and assign it the given Value object', function () {
+            state.defineSuperGlobal('MY_SUPER_GLOB', valueFactory.createInteger(27));
 
-            state.defineSuperGlobal('MY_SUPER_GLOB', value);
+            expect(state.getSuperGlobalScope().getVariable('MY_SUPER_GLOB').getValue().getNative()).to.equal(27);
+        });
 
-            expect(state.getSuperGlobalScope().getVariable('MY_SUPER_GLOB').getValue().getNative()).to.equal(101);
+        it('should be able to define a superglobal and assign it the given native value', function () {
+            state.defineSuperGlobal('MY_SUPER_GLOB', 1001);
+
+            expect(state.getSuperGlobalScope().getVariable('MY_SUPER_GLOB').getValue().getNative()).to.equal(1001);
         });
     });
 

--- a/test/unit/Reference/ElementTest.js
+++ b/test/unit/Reference/ElementTest.js
@@ -127,13 +127,17 @@ describe('ElementReference', function () {
         });
     });
 
-    describe('getPair()', function () {
-        it('should return a KeyValuePair when the element has a value', function () {
-            var pair = element.getPair();
+    describe('getPairForAssignment()', function () {
+        it('should return a KeyValuePair when the element has a value, with value fetched for assignment', function () {
+            var pair,
+                valueForAssignment = sinon.createStubInstance(Value);
+            value.getForAssignment.returns(valueForAssignment);
+
+            pair = element.getPairForAssignment();
 
             expect(pair).to.be.an.instanceOf(KeyValuePair);
             expect(pair.getKey()).to.equal(keyValue);
-            expect(pair.getValue()).to.equal(value);
+            expect(pair.getValue()).to.equal(valueForAssignment);
         });
 
         it('should return a KeyReferencePair when the element is a reference', function () {
@@ -141,7 +145,7 @@ describe('ElementReference', function () {
                 reference = sinon.createStubInstance(Reference);
             element.setReference(reference);
 
-            pair = element.getPair();
+            pair = element.getPairForAssignment();
 
             expect(pair).to.be.an.instanceOf(KeyReferencePair);
             expect(pair.getKey()).to.equal(keyValue);
@@ -150,7 +154,7 @@ describe('ElementReference', function () {
 
         it('should allow the key to be overridden when specified', function () {
             var overrideKey = valueFactory.createInteger(21),
-                pair = element.getPair(overrideKey);
+                pair = element.getPairForAssignment(overrideKey);
 
             expect(pair).to.be.an.instanceOf(KeyValuePair);
             expect(pair.getKey()).to.equal(overrideKey);
@@ -166,7 +170,7 @@ describe('ElementReference', function () {
                     keyValue
                 );
 
-                element.getPair();
+                element.getPairForAssignment();
             }).to.throw('Element is not defined');
         });
     });

--- a/test/unit/Reference/ReferenceSlotTest.js
+++ b/test/unit/Reference/ReferenceSlotTest.js
@@ -147,7 +147,7 @@ describe('ReferenceSlot', function () {
             reference.setValue(originalValue);
         });
 
-        it('should assign the incremented value to the referenced variable', function () {
+        it('should assign the incremented value to the slot', function () {
             reference.postIncrement();
 
             expect(reference.getValue()).to.equal(incrementedValue);
@@ -169,7 +169,7 @@ describe('ReferenceSlot', function () {
             reference.setValue(originalValue);
         });
 
-        it('should assign the decremented value to the referenced variable', function () {
+        it('should assign the decremented value to the slot', function () {
             reference.preDecrement();
 
             expect(reference.getValue()).to.equal(decrementedValue);
@@ -191,7 +191,7 @@ describe('ReferenceSlot', function () {
             reference.setValue(originalValue);
         });
 
-        it('should assign the incremented value to the referenced variable', function () {
+        it('should assign the incremented value to the slot', function () {
             reference.preIncrement();
 
             expect(reference.getValue()).to.equal(incrementedValue);

--- a/test/unit/RuntimeTest.js
+++ b/test/unit/RuntimeTest.js
@@ -240,7 +240,7 @@ describe('Runtime', function () {
     });
 
     describe('createEnvironment()', function () {
-        it('should create a new State instance correctly', function () {
+        it('should create a new State instance correctly when no additional plugins are specified', function () {
             this.runtime.createEnvironment({
                 myOption: 21
             });
@@ -266,6 +266,63 @@ describe('Runtime', function () {
                 {myOption: 21}
             );
         });
+
+        it('should create a new State instance correctly when additional plugins are specified', function () {
+            var bindingGroup = sinon.stub(),
+                classes = {MyClass: sinon.stub()},
+                classGroup = sinon.stub(),
+                constantGroup = sinon.stub(),
+                defaultINIGroup = sinon.stub(),
+                functionGroup = sinon.stub(),
+                optionGroup = sinon.stub(),
+                translationCatalogue = sinon.stub();
+
+            this.runtime.createEnvironment({
+                myOption: 21
+            }, [
+                // Standard plugin using a plain object
+                {
+                    bindingGroups: [bindingGroup],
+                    classGroups: [classGroup],
+                    classes: classes,
+                    constantGroups: [constantGroup]
+                },
+                function () {
+                    // Plugins may also be a function that is called to fetch the plugin data object
+
+                    return {
+                        defaultINIGroups: [defaultINIGroup],
+                        functionGroups: [functionGroup],
+                        optionGroups: [optionGroup],
+                        translationCatalogues: [translationCatalogue]
+                    };
+                }
+            ]);
+
+            expect(this.PHPState).to.have.been.calledOnce;
+            expect(this.PHPState).to.have.been.calledWith(
+                sinon.match.same(this.runtime),
+                {
+                    bindingGroups: [bindingGroup],
+                    classGroups: [classGroup],
+                    classes: classes,
+                    constantGroups: [constantGroup],
+                    defaultINIGroups: [defaultINIGroup],
+                    functionGroups: [functionGroup],
+                    translationCatalogues: [translationCatalogue]
+                },
+                sinon.match.instanceOf(Stream),
+                sinon.match.instanceOf(Stream),
+                sinon.match.instanceOf(Stream),
+                sinon.match.same(this.pausable),
+                'async',
+                [
+                    optionGroup
+                ],
+                {myOption: 21}
+            );
+        });
+
 
         it('should create a new Environment instance correctly', function () {
             var state = sinon.createStubInstance(this.PHPState);

--- a/test/unit/RuntimeTest.js
+++ b/test/unit/RuntimeTest.js
@@ -191,6 +191,28 @@ describe('Runtime', function () {
                 );
             });
 
+            it('should return a nestable factory function that provides overridable default options', function () {
+                var subFactory = factory
+                    .using({'my-option': 'initial value'})
+                    .using({'my-option': 'second value', 'your-option': 'unchanged value'})
+                    .using({'my-option': 'third value'});
+
+                subFactory({'my-option': 'final value'}); // Overrides the default `my-option` with value 'final option'
+
+                expect(Engine).to.have.been.calledOnce;
+                expect(Engine).to.have.been.calledWith(
+                    sinon.match.instanceOf(Environment),
+                    null,
+                    sinon.match.same(phpCommon),
+                    {
+                        'my-option': 'final value',
+                        'your-option': 'unchanged value'
+                    },
+                    sinon.match.same(wrapper),
+                    sinon.match.same(pausable)
+                );
+            });
+
             it('should return a factory function that provides a default Environment', function () {
                 var environment = sinon.createStubInstance(Environment),
                     subFactory = factory.using({}, environment);

--- a/test/unit/RuntimeTest.js
+++ b/test/unit/RuntimeTest.js
@@ -340,6 +340,46 @@ describe('Runtime', function () {
             );
         });
 
+        it('should keep plugins isolated to the environment they were installed into', function () {
+            runtime.createEnvironment({
+                myOption: 21
+            }, [
+                // Standard plugin using a plain object
+                {
+                    bindingGroups: [sinon.stub()]
+                },
+                function () {
+                    // Plugins may also be a function that is called to fetch the plugin data object
+
+                    return {
+                        functionGroups: [sinon.stub()]
+                    };
+                }
+            ]);
+            PHPState.resetHistory();
+            runtime.createEnvironment({myOption: 101});
+
+            expect(PHPState).to.have.been.calledOnce;
+            expect(PHPState).to.have.been.calledWith(
+                sinon.match.same(runtime),
+                {
+                    bindingGroups: [],
+                    classGroups: [],
+                    classes: {},
+                    constantGroups: [],
+                    defaultINIGroups: [],
+                    functionGroups: [],
+                    translationCatalogues: []
+                },
+                sinon.match.instanceOf(Stream),
+                sinon.match.instanceOf(Stream),
+                sinon.match.instanceOf(Stream),
+                sinon.match.same(pausable),
+                'async',
+                [],
+                {myOption: 101}
+            );
+        });
 
         it('should create a new Environment instance correctly', function () {
             var state = sinon.createStubInstance(PHPState);

--- a/test/unit/RuntimeTest.js
+++ b/test/unit/RuntimeTest.js
@@ -213,6 +213,91 @@ describe('Runtime', function () {
                 );
             });
 
+            it('should not allow the special "path" option to be overridden once set', function () {
+                var subFactory = factory
+                    .using({'my-option': 'initial value', 'path': '/the/path/to/use'})
+                    .using({'my-option': 'second value', 'path': '/ignored/second/path'})
+                    .using({'my-option': 'third value'});
+
+                subFactory({
+                    'my-option': 'final value',
+                    'path': '/ignored/third/path'
+                });
+
+                expect(Engine).to.have.been.calledOnce;
+                expect(Engine).to.have.been.calledWith(
+                    sinon.match.any,
+                    sinon.match.any,
+                    sinon.match.any,
+                    sinon.match({
+                        'path': '/the/path/to/use'
+                    })
+                );
+            });
+
+            it('should allow overriding the "path" option from a given Environment', function () {
+                var environment = sinon.createStubInstance(Environment),
+                    subFactory;
+                environment.getOptions.returns({
+                    path: '/inherited/path/option/to/ignore'
+                });
+                subFactory = factory
+                    .using({'my-option': 'initial value', 'path': '/the/path/to/use'})
+                    .using({'my-option': 'second value', 'path': '/ignored/second/path'})
+                    .using({'my-option': 'third value'});
+
+                subFactory({
+                    'my-option': 'final value',
+                    'path': '/ignored/third/path'
+                }, environment);
+
+                expect(Engine).to.have.been.calledOnce;
+                expect(Engine).to.have.been.calledWith(
+                    sinon.match.any,
+                    sinon.match.any,
+                    sinon.match.any,
+                    sinon.match({
+                        'path': '/the/path/to/use'
+                    })
+                );
+            });
+
+            it('should support no arguments being passed (although pointless usage)', function () {
+                var subFactory = factory.using(); // No args passed to .using(...)
+
+                subFactory({
+                    'my-option': 'my value'
+                });
+
+                expect(Engine).to.have.been.calledOnce;
+                expect(Engine).to.have.been.calledWith(
+                    sinon.match.any,
+                    sinon.match.any,
+                    sinon.match.any,
+                    sinon.match({
+                        'my-option': 'my value'
+                    })
+                );
+            });
+
+            it('should support no arguments being passed to the resulting new factory (although pointless usage)', function () {
+                var subFactory = factory.using({
+                    'path': 'my/path'
+                });
+
+                subFactory(); // No args passed to the factory function
+
+                expect(Engine).to.have.been.calledOnce;
+                expect(Engine).to.have.been.calledWith(
+                    sinon.match.any,
+                    sinon.match.any,
+                    sinon.match.any,
+                    sinon.match({
+                        'path': 'my/path'
+                    })
+                );
+            });
+
             it('should return a factory function that provides a default Environment', function () {
                 var environment = sinon.createStubInstance(Environment),
                     subFactory = factory.using({}, environment);

--- a/test/unit/RuntimeTest.js
+++ b/test/unit/RuntimeTest.js
@@ -364,7 +364,7 @@ describe('Runtime', function () {
     });
 
     describe('createEnvironment()', function () {
-        it('should create a new State instance correctly when no additional plugins are specified', function () {
+        it('should create a new State instance correctly when no additional addons are specified', function () {
             runtime.createEnvironment({
                 myOption: 21
             });
@@ -391,7 +391,7 @@ describe('Runtime', function () {
             );
         });
 
-        it('should create a new State instance correctly when additional plugins are specified', function () {
+        it('should create a new State instance correctly when additional addons are specified', function () {
             var bindingGroup = sinon.stub(),
                 classes = {MyClass: sinon.stub()},
                 classGroup = sinon.stub(),
@@ -404,7 +404,7 @@ describe('Runtime', function () {
             runtime.createEnvironment({
                 myOption: 21
             }, [
-                // Standard plugin using a plain object
+                // Standard addon using a plain object
                 {
                     bindingGroups: [bindingGroup],
                     classGroups: [classGroup],
@@ -412,7 +412,7 @@ describe('Runtime', function () {
                     constantGroups: [constantGroup]
                 },
                 function () {
-                    // Plugins may also be a function that is called to fetch the plugin data object
+                    // Addons may also be a function that is called to fetch the addon data object
 
                     return {
                         defaultINIGroups: [defaultINIGroup],
@@ -447,16 +447,16 @@ describe('Runtime', function () {
             );
         });
 
-        it('should keep plugins isolated to the environment they were installed into', function () {
+        it('should keep addons isolated to the environment they were installed into', function () {
             runtime.createEnvironment({
                 myOption: 21
             }, [
-                // Standard plugin using a plain object
+                // Standard addon using a plain object
                 {
                     bindingGroups: [sinon.stub()]
                 },
                 function () {
-                    // Plugins may also be a function that is called to fetch the plugin data object
+                    // Addons may also be a function that is called to fetch the addon data object
 
                     return {
                         functionGroups: [sinon.stub()]

--- a/test/unit/ScopeTest.js
+++ b/test/unit/ScopeTest.js
@@ -226,6 +226,37 @@ describe('Scope', function () {
         });
     });
 
+    describe('defineVariable()', function () {
+        it('should define a variable with the specified name in this scope', function () {
+            createScope();
+
+            scope.defineVariable('myVar');
+
+            expect(scope.hasVariable('myVar')).to.be.true;
+        });
+
+        it('should return the defined variable', function () {
+            var variable;
+            createScope();
+
+            variable = scope.defineVariable('myVar');
+
+            expect(variable).to.be.an.instanceOf(Variable);
+            expect(variable.getName()).to.equal('myVar');
+        });
+
+        it('should throw when a variable is already defined with the given name', function () {
+            createScope();
+            scope.defineVariable('myVar');
+
+            expect(function () {
+                scope.defineVariable('myVar');
+            }).to.throw(
+                'Variable "myVar" is already defined in this scope'
+            );
+        });
+    });
+
     describe('exportVariables()', function () {
         it('should export all defined variables in addition to the super globals', function () {
             var superGlobalValue = sinon.createStubInstance(Value),
@@ -514,6 +545,28 @@ describe('Scope', function () {
             createScope();
 
             expect(scope.getVariable('_ENV')).to.equal(superGlobal);
+        });
+    });
+
+    describe('hasVariable()', function () {
+        it('should return true when the specified variable is defined', function () {
+            createScope();
+            scope.defineVariable('myVar', 21);
+
+            expect(scope.hasVariable('myVar')).to.be.true;
+        });
+
+        it('should return true when the specified variable is defined and happens to be called "hasOwnProperty"', function () {
+            createScope();
+            scope.defineVariable('hasOwnProperty', 101);
+
+            expect(scope.hasVariable('hasOwnProperty')).to.be.true;
+        });
+
+        it('should return false when the specified variable is not defined', function () {
+            createScope();
+
+            expect(scope.hasVariable('myUndefinedVar')).to.be.false;
         });
     });
 

--- a/test/unit/Value/ArrayTest.js
+++ b/test/unit/Value/ArrayTest.js
@@ -369,6 +369,16 @@ describe('Array', function () {
         });
     });
 
+    describe('clone()', function () {
+        it('should raise an error', function () {
+            expect(function () {
+                value.clone();
+            }).to.throw(
+                'Fake PHP Fatal error for #core.method_called_on_non_object with {"method":"__clone"}'
+            );
+        });
+    });
+
     describe('coerceToNativeError()', function () {
         it('should throw an error as this is invalid', function () {
             expect(function () {
@@ -635,6 +645,32 @@ describe('Array', function () {
             expect(pair.getKey().getNative()).to.equal(21);
             expect(pair.getValue()).to.be.an.instanceOf(StringValue);
             expect(pair.getValue().getNative()).to.equal('value of first el');
+        });
+    });
+
+    describe('getForAssignment()', function () {
+        it('should return a copy of the array', function () {
+            var cloneValue = value.getForAssignment();
+
+            expect(cloneValue).to.not.equal(value);
+            expect(cloneValue.getNative()).to.deep.equal(value.getNative());
+        });
+
+        it('should perform a shallow copy of non-array descendants', function () {
+            var cloneValue,
+                elementKey3 = factory.createString('secondEl'),
+                elementValue3 = sinon.createStubInstance(ObjectValue),
+                element3 = createKeyValuePair(
+                    elementKey3,
+                    elementValue3
+                );
+            elementValue3.getForAssignment.returns(elementValue3);
+            elements.push(element3);
+            createValue();
+
+            cloneValue = value.getForAssignment();
+
+            expect(cloneValue.getElementByKey(elementKey3).getValue()).to.equal(elementValue3);
         });
     });
 

--- a/test/unit/Value/BooleanTest.js
+++ b/test/unit/Value/BooleanTest.js
@@ -89,6 +89,16 @@ describe('Boolean', function () {
         });
     });
 
+    describe('clone()', function () {
+        it('should raise an error', function () {
+            expect(function () {
+                value.clone();
+            }).to.throw(
+                'Fake PHP Fatal error for #core.method_called_on_non_object with {"method":"__clone"}'
+            );
+        });
+    });
+
     describe('coerceToNativeError()', function () {
         it('should throw an error as this is invalid', function () {
             expect(function () {

--- a/test/unit/Value/FloatTest.js
+++ b/test/unit/Value/FloatTest.js
@@ -89,6 +89,16 @@ describe('Float', function () {
         });
     });
 
+    describe('clone()', function () {
+        it('should raise an error', function () {
+            expect(function () {
+                value.clone();
+            }).to.throw(
+                'Fake PHP Fatal error for #core.method_called_on_non_object with {"method":"__clone"}'
+            );
+        });
+    });
+
     describe('coerceToNativeError()', function () {
         it('should throw an error as this is invalid', function () {
             expect(function () {

--- a/test/unit/Value/IntegerTest.js
+++ b/test/unit/Value/IntegerTest.js
@@ -89,6 +89,16 @@ describe('Integer', function () {
         });
     });
 
+    describe('clone()', function () {
+        it('should raise an error', function () {
+            expect(function () {
+                value.clone();
+            }).to.throw(
+                'Fake PHP Fatal error for #core.method_called_on_non_object with {"method":"__clone"}'
+            );
+        });
+    });
+
     describe('coerceToNativeError()', function () {
         it('should throw an error as this is invalid', function () {
             expect(function () {

--- a/test/unit/Value/NullTest.js
+++ b/test/unit/Value/NullTest.js
@@ -89,6 +89,16 @@ describe('Null', function () {
         });
     });
 
+    describe('clone()', function () {
+        it('should raise an error', function () {
+            expect(function () {
+                value.clone();
+            }).to.throw(
+                'Fake PHP Fatal error for #core.method_called_on_non_object with {"method":"__clone"}'
+            );
+        });
+    });
+
     describe('coerceToNativeError()', function () {
         it('should throw an error as this is invalid', function () {
             expect(function () {

--- a/test/unit/Value/ObjectTest.js
+++ b/test/unit/Value/ObjectTest.js
@@ -305,6 +305,59 @@ describe('Object', function () {
         });
     });
 
+    describe('clone()', function () {
+        it('should return an instance created via Class.instantiateBare(...)', function () {
+            var cloneInstance = sinon.createStubInstance(ObjectValue);
+            this.classObject.instantiateBare
+                .withArgs([])
+                .returns(cloneInstance);
+
+            expect(this.value.clone()).to.equal(cloneInstance);
+        });
+
+        it('should copy any instance properties from the original to the clone', function () {
+            var cloneInstance = sinon.createStubInstance(ObjectValue);
+            this.classObject.instantiateBare
+                .withArgs([])
+                .returns(cloneInstance);
+
+            this.value.clone();
+
+            expect(cloneInstance.setProperty).to.have.been.calledTwice;
+            expect(cloneInstance.setProperty).to.have.been.calledWith('firstProp', sinon.match.same(this.prop1));
+            expect(cloneInstance.setProperty).to.have.been.calledWith('secondProp', sinon.match.same(this.prop2));
+        });
+
+        it('should call the magic __clone() method on the clone if defined', function () {
+            var cloneInstance = sinon.createStubInstance(ObjectValue);
+            this.classObject.instantiateBare
+                .withArgs([])
+                .returns(cloneInstance);
+            cloneInstance.isMethodDefined
+                .withArgs('__clone')
+                .returns(true);
+
+            this.value.clone();
+
+            expect(cloneInstance.callMethod).to.have.been.calledOnce;
+            expect(cloneInstance.callMethod).to.have.been.calledWith('__clone');
+        });
+
+        it('should not call the magic __clone() method on the original if defined', function () {
+            var cloneInstance = sinon.createStubInstance(ObjectValue);
+            this.classObject.instantiateBare
+                .withArgs([])
+                .returns(cloneInstance);
+            cloneInstance.isMethodDefined
+                .withArgs('__clone')
+                .returns(false);
+
+            this.value.clone();
+
+            expect(cloneInstance.callMethod).not.to.have.been.called;
+        });
+    });
+
     describe('coerceToArray()', function () {
         it('should handle an empty object', function () {
             var objectValue = new ObjectValue(
@@ -1521,6 +1574,15 @@ describe('Object', function () {
     describe('getObject()', function () {
         it('should return the wrapped native object', function () {
             expect(this.value.getObject()).to.equal(this.nativeObject);
+        });
+    });
+
+    describe('getPropertyNames()', function () {
+        it('should return all instance property names as native strings', function () {
+            expect(this.value.getPropertyNames()).to.deep.equal([
+                'firstProp',
+                'secondProp'
+            ]);
         });
     });
 

--- a/test/unit/Value/StringTest.js
+++ b/test/unit/Value/StringTest.js
@@ -181,6 +181,18 @@ describe('String', function () {
         });
     });
 
+    describe('clone()', function () {
+        it('should raise an error', function () {
+            createValue('my string');
+
+            expect(function () {
+                value.clone();
+            }).to.throw(
+                'Fake PHP Fatal error for #core.method_called_on_non_object with {"method":"__clone"}'
+            );
+        });
+    });
+
     describe('coerceToFloat()', function () {
         _.each({
             'coercing a positive plain integer to float': {

--- a/test/unit/VariableTest.js
+++ b/test/unit/VariableTest.js
@@ -13,6 +13,7 @@ var expect = require('chai').expect,
     phpCommon = require('phpcommon'),
     sinon = require('sinon'),
     CallStack = require('../../src/CallStack'),
+    IntegerValue = require('../../src/Value/Integer').sync(),
     ObjectValue = require('../../src/Value/Object').sync(),
     PHPError = phpCommon.PHPError,
     PropertyReference = require('../../src/Reference/Property'),
@@ -301,6 +302,102 @@ describe('Variable', function () {
             variable.setValue(value);
 
             expect(variable.isEmpty()).to.be.false;
+        });
+    });
+
+    describe('postDecrement()', function () {
+        var decrementedValue,
+            originalValue;
+
+        beforeEach(function () {
+            originalValue = sinon.createStubInstance(IntegerValue);
+            decrementedValue = sinon.createStubInstance(IntegerValue);
+            decrementedValue.getForAssignment.returns(decrementedValue);
+            originalValue.decrement.returns(decrementedValue);
+            originalValue.getForAssignment.returns(originalValue);
+            variable.setValue(originalValue);
+        });
+
+        it('should assign the decremented value to the variable', function () {
+            variable.postDecrement();
+
+            expect(variable.getValue()).to.equal(decrementedValue);
+        });
+
+        it('should return the original value', function () {
+            expect(variable.postDecrement()).to.equal(originalValue);
+        });
+    });
+
+    describe('postIncrement()', function () {
+        var incrementedValue,
+            originalValue;
+
+        beforeEach(function () {
+            originalValue = sinon.createStubInstance(IntegerValue);
+            incrementedValue = sinon.createStubInstance(IntegerValue);
+            incrementedValue.getForAssignment.returns(incrementedValue);
+            originalValue.increment.returns(incrementedValue);
+            originalValue.getForAssignment.returns(originalValue);
+            variable.setValue(originalValue);
+        });
+
+        it('should assign the incremented value to the variable', function () {
+            variable.postIncrement();
+
+            expect(variable.getValue()).to.equal(incrementedValue);
+        });
+
+        it('should return the original value', function () {
+            expect(variable.postIncrement()).to.equal(originalValue);
+        });
+    });
+
+    describe('preDecrement()', function () {
+        var decrementedValue,
+            originalValue;
+
+        beforeEach(function () {
+            originalValue = sinon.createStubInstance(IntegerValue);
+            decrementedValue = sinon.createStubInstance(IntegerValue);
+            decrementedValue.getForAssignment.returns(decrementedValue);
+            originalValue.decrement.returns(decrementedValue);
+            originalValue.getForAssignment.returns(originalValue);
+            variable.setValue(originalValue);
+        });
+
+        it('should assign the decremented value to the variable', function () {
+            variable.preDecrement();
+
+            expect(variable.getValue()).to.equal(decrementedValue);
+        });
+
+        it('should return the decremented value', function () {
+            expect(variable.preDecrement()).to.equal(decrementedValue);
+        });
+    });
+
+    describe('preIncrement()', function () {
+        var incrementedValue,
+            originalValue;
+
+        beforeEach(function () {
+            originalValue = sinon.createStubInstance(IntegerValue);
+            incrementedValue = sinon.createStubInstance(IntegerValue);
+            incrementedValue.getForAssignment.returns(incrementedValue);
+            originalValue.increment.returns(incrementedValue);
+            originalValue.getForAssignment.returns(originalValue);
+            variable.setValue(originalValue);
+        });
+
+        it('should assign the incremented value to the referenced variable', function () {
+            variable.preIncrement();
+
+            expect(variable.getValue()).to.equal(incrementedValue);
+        });
+
+        it('should return the incremented value', function () {
+            expect(variable.preIncrement()).to.equal(incrementedValue);
         });
     });
 


### PR DESCRIPTION
- Add support for the special "namespace" keyword prefix in class paths
- Implement PHP `clone ...` operator
- Fix issue with stack frame path when from function called by included file
- Add support for installing additional plugins into an environment, without installing them into the runtime itself (part of unified platform config changes)
- Fix issue with directory traversal symbols appearing in stack traces
- Allow `.using(...)` to be chained indefinitely on module factory functions
- Allow the include transport to provide an absolute path
- Fix issue when passing an instance of an auto-coercing class into another
- Auto-coerce the value of a superglobal when defined via the `Environment` too
- Rename "plugin" to "addon" to avoid confusion with PHPConfig's unified platform plugins