### PR TITLE
Use the underlying/source error when composing load error messages

### DIFF
--- a/src/Load/Includer.js
+++ b/src/Load/Includer.js
@@ -104,7 +104,8 @@ module.exports = require('pauser')([
         ) {
             var includer = this,
                 includeFunction = includer.optionSet.getOption(INCLUDE_OPTION),
-                includeScope;
+                includeScope,
+                previousError;
 
             if (!includeFunction) {
                 throw new Exception(
@@ -141,9 +142,12 @@ module.exports = require('pauser')([
                     throw error;
                 }
 
+                previousError = error.getPreviousError();
+
                 includer.callStack.raiseError(
                     PHPError.E_WARNING,
-                    type + '(' + includedPath + '): failed to open stream: No such file or directory'
+                    type + '(' + includedPath + '): failed to open stream: ' +
+                        (previousError ? previousError.message : 'Unknown error')
                 );
                 includer.callStack.raiseError(
                     errorLevel,

--- a/test/integration/asyncIncludeTest.js
+++ b/test/integration/asyncIncludeTest.js
@@ -50,7 +50,7 @@ EOS
             options = {
                 include: function (path, promise) {
                     setTimeout(function () {
-                        promise.reject();
+                        promise.reject(new Error('Oh dear!'));
                     });
                 }
             },
@@ -59,7 +59,7 @@ EOS
         engine.execute().then(when(done, function (result) {
             expect(result.getNative()).to.equal(false);
             expect(engine.getStderr().readAll()).to.equal(nowdoc(function () {/*<<<EOS
-PHP Warning:  include(abc.php): failed to open stream: No such file or directory in my_module.php on line 2
+PHP Warning:  include(abc.php): failed to open stream: Oh dear! in my_module.php on line 2
 PHP Warning:  include(): Failed opening 'abc.php' for inclusion in my_module.php on line 2
 
 EOS

--- a/test/integration/psyncIncludeTest.js
+++ b/test/integration/psyncIncludeTest.js
@@ -44,7 +44,7 @@ EOS
             module = tools.psyncTranspile('some/module.php', php),
             options = {
                 include: function (path, promise) {
-                    promise.reject();
+                    promise.reject(new Error('Oh dear!'));
                 }
             },
             engine = module(options);
@@ -52,7 +52,7 @@ EOS
         engine.execute().then(when(done, function (result) {
             expect(result.getNative()).to.equal(false);
             expect(engine.getStderr().readAll()).to.equal(nowdoc(function () {/*<<<EOS
-PHP Warning:  include(abc.php): failed to open stream: No such file or directory in some/module.php on line 2
+PHP Warning:  include(abc.php): failed to open stream: Oh dear! in some/module.php on line 2
 PHP Warning:  include(): Failed opening 'abc.php' for inclusion in some/module.php on line 2
 
 EOS

--- a/test/integration/syncIncludeOnceTest.js
+++ b/test/integration/syncIncludeOnceTest.js
@@ -82,7 +82,7 @@ EOS
 
         expect(engine.execute().getNative()).to.equal(false);
         expect(engine.getStderr().readAll()).to.equal(nowdoc(function () {/*<<<EOS
-PHP Warning:  include_once(abc.php): failed to open stream: No such file or directory in a_module.php on line 2
+PHP Warning:  include_once(abc.php): failed to open stream: Include failed in a_module.php on line 2
 PHP Warning:  include_once(): Failed opening 'abc.php' for inclusion in a_module.php on line 2
 
 EOS

--- a/test/integration/syncIncludeTest.js
+++ b/test/integration/syncIncludeTest.js
@@ -140,7 +140,7 @@ EOS
 
         expect(engine.execute().getNative()).to.equal(false);
         expect(engine.getStderr().readAll()).to.equal(nowdoc(function () {/*<<<EOS
-PHP Warning:  include(abc.php): failed to open stream: No such file or directory in a_module.php on line 2
+PHP Warning:  include(abc.php): failed to open stream: Include failed in a_module.php on line 2
 PHP Warning:  include(): Failed opening 'abc.php' for inclusion in a_module.php on line 2
 
 EOS

--- a/test/integration/syncRequireOnceTest.js
+++ b/test/integration/syncRequireOnceTest.js
@@ -89,7 +89,7 @@ EOS
             'PHP Fatal error: require_once(): Failed opening \'abc.php\' for inclusion in a_module.php on line 2'
         );
         expect(engine.getStderr().readAll()).to.equal(nowdoc(function () {/*<<<EOS
-PHP Warning:  require_once(abc.php): failed to open stream: No such file or directory in a_module.php on line 2
+PHP Warning:  require_once(abc.php): failed to open stream: Include failed in a_module.php on line 2
 PHP Fatal error:  require_once(): Failed opening 'abc.php' for inclusion in a_module.php on line 2
 
 EOS

--- a/test/integration/syncRequireTest.js
+++ b/test/integration/syncRequireTest.js
@@ -89,7 +89,7 @@ EOS
             'PHP Fatal error: require(): Failed opening \'abc.php\' for inclusion in a_module.php on line 2'
         );
         expect(engine.getStderr().readAll()).to.equal(nowdoc(function () {/*<<<EOS
-PHP Warning:  require(abc.php): failed to open stream: No such file or directory in a_module.php on line 2
+PHP Warning:  require(abc.php): failed to open stream: Include failed in a_module.php on line 2
 PHP Fatal error:  require(): Failed opening 'abc.php' for inclusion in a_module.php on line 2
 
 EOS


### PR DESCRIPTION
Previously, the original error thrown when an include or require failed was swallowed and a generic "... No such file or directory" message was shown. This change embeds the underlying error at that point in the string, to allow easier debugging of more exotic load setups (eg. in [PHPify](https://github.com/uniter/phpify)).

Note that the correct error message "... No such file or directory" should still be shown when appropriate, by [DotPHP](https://github.com/uniter/dotphp).