### PR TITLE
Re-entrancy support

### DIFF
--- a/src/CallStack.js
+++ b/src/CallStack.js
@@ -41,6 +41,13 @@ function CallStack(valueFactory, translator, errorReporting) {
 
 _.extend(CallStack.prototype, {
     /**
+     * Clears the current stack state.
+     */
+    clear: function () {
+        this.calls.length = 0;
+    },
+
+    /**
      * Fetches the previous Call near the top of the stack, or null if none
      *
      * @returns {Call|null}
@@ -159,10 +166,12 @@ _.extend(CallStack.prototype, {
     /**
      * Fetches the scope of the current call
      *
-     * @returns {Scope}
+     * @returns {Scope|null}
      */
     getCurrentScope: function () {
-        return this.getCurrent().getScope();
+        var currentCall = this.getCurrent();
+
+        return currentCall ? currentCall.getScope() : null;
     },
 
     /**
@@ -563,18 +572,12 @@ _.extend(CallStack.prototype, {
         var stack = this;
 
         if (stack.calls.length > 0) {
-            throw new Error('Cannot restore when not paused');
+            stack.calls.length = 0;
         }
 
-        [].push.apply(stack.calls, savedCalls);
-
-        // var stack = this;
-        //
-        // if (stack.calls.length > 0 && savedCalls.length > 0) {
-        //     stack.calls.length = 0;
-        // }
-        //
-        // [].push.apply(stack.calls, savedCalls);
+        if (savedCalls.length > 0) {
+            [].push.apply(stack.calls, savedCalls);
+        }
     },
 
     /**
@@ -594,19 +597,12 @@ _.extend(CallStack.prototype, {
     },
 
     /**
-     * Pauses the current call stack, returning the current stack state
-     * and clearing the stack contents
+     * Fetches a copy of the current stack state without clearing it.
      *
      * @returns {Call[]}
      */
     save: function () {
-        var stack = this,
-            calls = stack.calls.slice();
-
-        // Clear the current call stack
-        stack.calls.length = 0;
-
-        return calls;
+        return this.calls.slice();
     },
 
     /**

--- a/src/ClassAutoloader.js
+++ b/src/ClassAutoloader.js
@@ -82,7 +82,6 @@ module.exports = require('pauser')([
 
                 return autoloader.flow.eachAsync(splStack, function (autoloadCallable) {
                     return autoloadCallable.call([autoloader.valueFactory.createString(name)], globalNamespace)
-                        .getValue()
                         .asFuture() // We must switch to a future, because we sometimes resolve with a scalar just below
                         .next(function () {
                             if (globalNamespace.hasClass(name)) {

--- a/src/Control/ControlScope.js
+++ b/src/Control/ControlScope.js
@@ -9,22 +9,99 @@
 
 'use strict';
 
-var _ = require('microdash');
+var _ = require('microdash'),
+    phpCommon = require('phpcommon'),
+    Exception = phpCommon.Exception;
 
 /**
  * @constructor
  */
 function ControlScope() {
     /**
+     * @type {CoroutineFactory}
+     */
+    this.coroutineFactory = null;
+    /**
+     * @type {Coroutine|null}
+     */
+    this.currentCoroutine = null;
+    /**
      * @type {Pause|null}
      */
     this.currentPause = null;
+    /**
+     * @type {boolean}
+     */
+    this.nestNextCoroutine = false;
 }
 
 _.extend(ControlScope.prototype, {
     /**
+     * Enters a new coroutine, or continues the current one if we are nesting.
+     *
+     * @returns {Coroutine}
+     */
+    enterCoroutine: function () {
+        var scope = this,
+            newCoroutine;
+
+        if (scope.nestNextCoroutine) {
+            scope.nestNextCoroutine = false;
+
+            if (scope.currentCoroutine === null) {
+                throw new Exception('ControlScope.enterCoroutine() :: Unable to nest - no coroutine is active');
+            }
+
+            return scope.currentCoroutine;
+        }
+
+        newCoroutine = scope.coroutineFactory.createCoroutine();
+
+        if (scope.currentCoroutine !== null) {
+            scope.currentCoroutine.suspend();
+        }
+
+        scope.currentCoroutine = newCoroutine;
+
+        return scope.currentCoroutine;
+    },
+
+    /**
+     * Fetches the current coroutine.
+     *
+     * @returns {Coroutine}
+     */
+    getCoroutine: function () {
+        var scope = this;
+
+        if (scope.currentCoroutine === null) {
+            throw new Exception('ControlScope.getCoroutine() :: Invalid state - no coroutine is active');
+        }
+
+        return scope.currentCoroutine;
+    },
+
+    /**
+     * Fetches whether there is a current coroutine.
+     *
+     * @returns {boolean}
+     */
+    inCoroutine: function () {
+        return this.currentCoroutine !== null;
+    },
+
+    /**
+     * Fetches whether the next coroutine has been marked as nested.
+     *
+     * @returns {boolean}
+     */
+    isNestingCoroutine: function () {
+        return this.nestNextCoroutine;
+    },
+
+    /**
      * Determines whether we are currently in the process of pausing (a Pause has been created and thrown,
-     * but it has not yet fully unwound the call stack inside the runtime)
+     * but it has not yet fully unwound the call stack inside the runtime).
      *
      * @returns {boolean}
      */
@@ -33,7 +110,7 @@ _.extend(ControlScope.prototype, {
     },
 
     /**
-     * Mark that the given current pause has finished being handled
+     * Mark that the given current pause has finished being handled.
      *
      * @param {Pause} pause
      */
@@ -41,18 +118,18 @@ _.extend(ControlScope.prototype, {
         var scope = this;
 
         if (scope.currentPause === null) {
-            throw new Error('ControlScope.markPaused() :: Invalid state - no pause is currently taking effect');
+            throw new Exception('ControlScope.markPaused() :: Invalid state - no pause is currently taking effect');
         }
 
         if (pause !== scope.currentPause) {
-            throw new Error('ControlScope.markPaused() :: Invalid state - wrong pause');
+            throw new Exception('ControlScope.markPaused() :: Invalid state - wrong pause');
         }
 
         scope.currentPause = null;
     },
 
     /**
-     * Mark that a pause is taking effect
+     * Mark that a pause is taking effect.
      *
      * @param {Pause} pause
      */
@@ -60,10 +137,63 @@ _.extend(ControlScope.prototype, {
         var scope = this;
 
         if (scope.currentPause !== null) {
-            throw new Error('ControlScope.markPausing() :: Invalid state - a pause is already taking effect');
+            /*
+             * Note that this does not preclude another pause from occurring while a pause is in effect -
+             * it ensures that a pause has fully taken effect (by unwinding the JS call stack)
+             * before another can begin.
+             */
+            throw new Exception('ControlScope.markPausing() :: Invalid state - a pause is already taking effect');
         }
 
         scope.currentPause = pause;
+    },
+
+    /**
+     * Marks the next coroutine as nested. For now this means the same one will be kept
+     * on next entry, i.e. no new coroutine will be created.
+     */
+    nestCoroutine: function () {
+        var scope = this;
+
+        if (scope.nestNextCoroutine) {
+            throw new Exception('ControlScope.nestCoroutine() :: Invalid state - already marked for nesting');
+        }
+
+        scope.nestNextCoroutine = true;
+    },
+
+    /**
+     * Restores a previously suspended or saved coroutine.
+     *
+     * @param {Coroutine} coroutine
+     */
+    resumeCoroutine: function (coroutine) {
+        var scope = this;
+
+        if (scope.currentPause !== null) {
+            throw new Exception('ControlScope.resumeCoroutine() :: Invalid state - a pause is currently taking effect');
+        }
+
+        if (scope.currentCoroutine !== coroutine) {
+            // Coroutine was not the current one, so suspend that one first.
+
+            if (scope.currentCoroutine !== null) {
+                scope.currentCoroutine.suspend();
+            }
+
+            scope.currentCoroutine = coroutine;
+        }
+
+        scope.currentCoroutine.resume();
+    },
+
+    /**
+     * Injects the CoroutineFactory service. Required to work around a circular dependency.
+     *
+     * @param {CoroutineFactory} coroutineFactory
+     */
+    setCoroutineFactory: function (coroutineFactory) {
+        this.coroutineFactory = coroutineFactory;
     }
 });
 

--- a/src/Control/Coroutine.js
+++ b/src/Control/Coroutine.js
@@ -1,0 +1,71 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var _ = require('microdash'),
+    phpCommon = require('phpcommon'),
+    Exception = phpCommon.Exception;
+
+/**
+ * Represents an independent call stack into PHP-land that can be suspended and later resumed.
+ * Used for multitasking, non-preemptively by default.
+ *
+ * @param {CallStack} callStack
+ * @constructor
+ */
+function Coroutine(callStack) {
+    /**
+     * @type {CallStack}
+     */
+    this.callStack = callStack;
+    /**
+     * Saved call stack frames for restoring.
+     *
+     * @type {Call[]|null}
+     */
+    this.savedCallStack = null;
+}
+
+_.extend(Coroutine.prototype, {
+    /**
+     * Resumes this coroutine, if it was previously suspended.
+     */
+    resume: function () {
+        var coroutine = this,
+            savedCallStack;
+
+        if (coroutine.savedCallStack === null) {
+            return;
+        }
+
+        savedCallStack = coroutine.savedCallStack;
+        coroutine.savedCallStack = null;
+
+        coroutine.callStack.restore(savedCallStack);
+    },
+
+    /**
+     * Suspends this coroutine, for later resumption.
+     */
+    suspend: function () {
+        var coroutine = this;
+
+        if (coroutine.savedCallStack !== null) {
+            throw new Exception('Coroutine.save() :: Invalid state - coroutine already suspended');
+        }
+
+        coroutine.savedCallStack = coroutine.callStack.save();
+
+        // Clear the call stack at this point, unlike .save().
+        coroutine.callStack.clear();
+    }
+});
+
+module.exports = Coroutine;

--- a/src/Control/CoroutineFactory.js
+++ b/src/Control/CoroutineFactory.js
@@ -1,0 +1,49 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var _ = require('microdash');
+
+/**
+ * @param {class} Coroutine
+ * @param {CallStack} callStack
+ * @constructor
+ */
+function CoroutineFactory(Coroutine, callStack) {
+    /**
+     * @type {CallStack}
+     */
+    this.callStack = callStack;
+    /**
+     * @type {class}
+     */
+    this.Coroutine = Coroutine;
+}
+
+_.extend(CoroutineFactory.prototype, {
+    /**
+     * Creates a new Coroutine.
+     *
+     * @returns {Coroutine}
+     */
+    createCoroutine: function () {
+        var factory = this,
+            coroutine = new factory.Coroutine(factory.callStack),
+            currentScope = factory.callStack.getCurrentScope();
+
+        if (currentScope) {
+            currentScope.updateCoroutine(coroutine);
+        }
+
+        return coroutine;
+    }
+});
+
+module.exports = CoroutineFactory;

--- a/src/Control/Flow.js
+++ b/src/Control/Flow.js
@@ -10,6 +10,7 @@
 'use strict';
 
 var _ = require('microdash'),
+    FFIResult = require('../FFI/Result'),
     Pause = require('./Pause');
 
 /**
@@ -57,9 +58,15 @@ _.extend(Flow.prototype, {
     chainify: function (value) {
         var flow = this;
 
-        return flow.controlBridge.isChainable(value) ?
-            value :
-            flow.futureFactory.createPresent(value);
+        if (flow.controlBridge.isChainable(value)) {
+            return value;
+        }
+
+        if (value instanceof FFIResult) {
+            return value.resolve();
+        }
+
+        return flow.futureFactory.createPresent(value);
     },
 
     /**

--- a/src/Control/FutureFactory.js
+++ b/src/Control/FutureFactory.js
@@ -16,6 +16,7 @@ var _ = require('microdash'),
  * @param {PauseFactory} pauseFactory
  * @param {ValueFactory} valueFactory
  * @param {ControlBridge} controlBridge
+ * @param {ControlScope} controlScope
  * @param {class} Future
  * @constructor
  */
@@ -23,12 +24,17 @@ function FutureFactory(
     pauseFactory,
     valueFactory,
     controlBridge,
+    controlScope,
     Future
 ) {
     /**
      * @type {ControlBridge}
      */
     this.controlBridge = controlBridge;
+    /**
+     * @type {ControlScope}
+     */
+    this.controlScope = controlScope;
     /**
      * @type {class}
      */
@@ -76,10 +82,9 @@ _.extend(FutureFactory.prototype, {
      * Creates a new Future
      *
      * @param {Function} executor
-     * @param {Future=} parent
      * @returns {Future}
      */
-    createFuture: function (executor, parent) {
+    createFuture: function (executor) {
         var factory = this;
 
         return new factory.Future(
@@ -87,16 +92,14 @@ _.extend(FutureFactory.prototype, {
             factory.pauseFactory,
             factory.valueFactory,
             factory.controlBridge,
+            factory.controlScope,
             executor,
-            parent || null
+            factory.controlScope.getCoroutine()
         );
     },
 
     /**
      * Creates a new present Future for the given value
-     *
-     * TODO: Reinstate an actual lightweight Present class to avoid the complexity of Futures when unnecessary,
-     *       however now that Sequence is defunct, perhaps less of an issue?
      *
      * @param {*} value
      * @returns {Future}

--- a/src/Control/HostScheduler.js
+++ b/src/Control/HostScheduler.js
@@ -1,0 +1,56 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var _ = require('microdash'),
+    queueMacrotask = typeof requestIdleCallback !== 'undefined' ?
+        function (callback) {
+            requestIdleCallback(callback);
+        } :
+        function (callback) {
+            setTimeout(callback, 1);
+        },
+    queueMicrotask = require('core-js-pure/actual/queue-microtask');
+
+/**
+ * Abstraction for host JavaScript environment event loop scheduling.
+ *
+ * TODO: Use me everywhere we currently use queueM[ai]crotask().
+ *
+ * @constructor
+ */
+function HostScheduler() {
+
+}
+
+_.extend(HostScheduler.prototype, {
+    /**
+     * Schedules a callback to run asynchronously in a macrotask
+     * (macrotasks wait for the _next_ event loop tick, allowing DOM events to fire etc.).
+     *
+     * @param {Function} callback
+     */
+    queueMacrotask: function (callback) {
+        return queueMacrotask(callback);
+    },
+
+    /**
+     * Schedules a callback to run asynchronously in a microtask
+     * (microtasks are called at the end of the _current_ event loop tick, so any DOM events etc.
+     * will not be fired in between).
+     *
+     * @param {Function} callback
+     */
+    queueMicrotask: function (callback) {
+        return queueMicrotask(callback);
+    }
+});
+
+module.exports = HostScheduler;

--- a/src/Element/ReferenceElement.js
+++ b/src/Element/ReferenceElement.js
@@ -1,0 +1,47 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var _ = require('microdash');
+
+/**
+ * Represents an element of an array whose key is unspecified and is to be a reference.
+ *
+ * @param {Reference} reference
+ * @constructor
+ */
+function ReferenceElement(reference) {
+    /**
+     * @type {Reference}
+     */
+    this.reference = reference;
+}
+
+_.extend(ReferenceElement.prototype, {
+    /**
+     * Returns this element unchanged.
+     *
+     * @returns {ReferenceElement}
+     */
+    asArrayElement: function () {
+        return this;
+    },
+
+    /**
+     * Fetches the reference.
+     *
+     * @returns {Reference}
+     */
+    getReference: function () {
+        return this.reference;
+    }
+});
+
+module.exports = ReferenceElement;

--- a/src/Environment.js
+++ b/src/Environment.js
@@ -108,9 +108,10 @@ _.extend(Environment.prototype, {
      * @param {string} name
      * @param {Function} valueGetter
      * @param {Function=} valueSetter
+     * @param {Function=} referenceSetter
      */
-    defineGlobalAccessor: function (name, valueGetter, valueSetter) {
-        this.state.defineGlobalAccessor(name, valueGetter, valueSetter);
+    defineGlobalAccessor: function (name, valueGetter, valueSetter, referenceSetter) {
+        this.state.defineGlobalAccessor(name, valueGetter, valueSetter, referenceSetter);
     },
 
     /**

--- a/src/FFI/FFIFactory.js
+++ b/src/FFI/FFIFactory.js
@@ -14,6 +14,7 @@ var _ = require('microdash');
 /**
  * @param {class} AsyncObjectValue
  * @param {class} PHPObject
+ * @param {class} ResultValue
  * @param {class} ValueCoercer
  * @param {ValueFactory} valueFactory
  * @param {ReferenceFactory} referenceFactory
@@ -27,6 +28,7 @@ var _ = require('microdash');
 function FFIFactory(
     AsyncObjectValue,
     PHPObject,
+    ResultValue,
     ValueCoercer,
     valueFactory,
     referenceFactory,
@@ -68,6 +70,10 @@ function FFIFactory(
      * @type {ReferenceFactory}
      */
     this.referenceFactory = referenceFactory;
+    /**
+     * @type {ResultValue}
+     */
+    this.ResultValue = ResultValue;
     /**
      * @type {ValueCaller}
      */
@@ -114,6 +120,19 @@ _.extend(FFIFactory.prototype, {
         var factory = this;
 
         return new factory.PHPObject(factory.valueFactory, factory.nativeCaller, objectValue);
+    },
+
+    /**
+     * Creates a ResultValue, which wraps an internal Value with its native value already resolved.
+     *
+     * @param {Value} internalValue
+     * @param {*} nativeValue
+     * @returns {ResultValue}
+     */
+    createResultValue: function (internalValue, nativeValue) {
+        var factory = this;
+
+        return new factory.ResultValue(internalValue, nativeValue);
     },
 
     /**

--- a/src/FFI/Result.js
+++ b/src/FFI/Result.js
@@ -18,9 +18,6 @@ var _ = require('microdash'),
  * a result that may be fetched asynchronously to be used in async mode
  * while also providing a way to fetch it synchronously in sync mode.
  *
- * TODO: Consider getting rid of this class and just creating & returning a FutureValue
- *       directly from PHPState.createFFIResult()?
- *
  * @param {Function} syncCallback
  * @param {Function=} asyncCallback
  * @param {ValueFactory} valueFactory

--- a/src/FFI/Value/Proxy/ProxyMemberFactory.js
+++ b/src/FFI/Value/Proxy/ProxyMemberFactory.js
@@ -17,13 +17,19 @@ var _ = require('microdash');
  * @param {ValueFactory} valueFactory
  * @param {ValueStorage} valueStorage
  * @param {NativeCaller} nativeCaller
+ * @param {ControlScope} controlScope
  * @constructor
  */
 function ProxyMemberFactory(
     valueFactory,
     valueStorage,
-    nativeCaller
+    nativeCaller,
+    controlScope
 ) {
+    /**
+     * @type {ControlScope}
+     */
+    this.controlScope = controlScope;
     /**
      * @type {NativeCaller}
      */
@@ -56,6 +62,9 @@ _.extend(ProxyMemberFactory.prototype, {
                 privates = factory.valueStorage.getPrivatesForNativeProxy(this),
                 objectValue = privates.objectValue,
                 useSyncApiAlthoughPsync = privates.useSyncApiAlthoughPsync;
+
+            // We are entering PHP-land from JS-land.
+            factory.controlScope.enterCoroutine();
 
             return factory.nativeCaller.callMethod(objectValue, methodName, args, useSyncApiAlthoughPsync);
         };

--- a/src/FFI/Value/ResultValue.js
+++ b/src/FFI/Value/ResultValue.js
@@ -1,0 +1,92 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var _ = require('microdash');
+
+/**
+ * Represents a result of execution returned from PHP-land to JS-land.
+ *
+ * @param {Value} internalValue
+ * @param {*} nativeValue
+ * @constructor
+ */
+function ResultValue(internalValue, nativeValue) {
+    /**
+     * @type {Value}
+     */
+    this.internalValue = internalValue;
+    /**
+     * @type {*}
+     */
+    this.nativeValue = nativeValue;
+}
+
+_.extend(ResultValue.prototype, {
+    /**
+     * Fetches the internal Value of the result.
+     *
+     * @returns {Value}
+     */
+    getInternalValue: function () {
+        return this.internalValue;
+    },
+
+    /**
+     * Fetches the previously-resolved native value of the result.
+     *
+     * @returns {*}
+     */
+    getNative: function () {
+        return this.nativeValue;
+    },
+
+    /**
+     * Exports a "proxying" version of the native value. For normal primitive values
+     * (string, boolean, int, float) this will just be the native value,
+     * but for objects it will be an instance of PHPObject (see ObjectValue.prototype.getProxy())
+     *
+     * @returns {*}
+     */
+    getProxy: function () {
+        var value = this;
+
+        return value.getType() === 'object' ?
+            // Only ObjectValues support proxying.
+            value.internalValue.getProxy() :
+            // For other value types, use the native value we already resolved.
+            value.nativeValue;
+    },
+
+    /**
+     * Fetches the exit code, if any, otherwise 0. Note this is only valid on exit -
+     * if the internal value was not an ExitValue then null will be returned.
+     *
+     * @returns {number|null}
+     */
+    getStatus: function () {
+        var value = this;
+
+        return value.internalValue.getType() === 'exit' ?
+            value.internalValue.getStatus() :
+            null;
+    },
+
+    /**
+     * Fetches the type of the result.
+     *
+     * @returns {string}
+     */
+    getType: function () {
+        return this.internalValue.getType();
+    }
+});
+
+module.exports = ResultValue;

--- a/src/KeyValuePair.js
+++ b/src/KeyValuePair.js
@@ -11,25 +11,60 @@
 
 var _ = require('microdash');
 
+/**
+ * Represents a key-value pair for an element of an associative array.
+ *
+ * TODO: Move to Element folder?
+ *
+ * @param {Value} key
+ * @param {Value} value
+ * @constructor
+ */
 function KeyValuePair(key, value) {
+    /**
+     * @type {Value}
+     */
     this.key = key;
+    /**
+     * @type {Value}
+     */
     this.value = value;
 }
 
 _.extend(KeyValuePair.prototype, {
     /**
-     * Returns this pair unchanged.
+     * Returns this pair with the value resolved to a present if necessary.
      *
-     * @returns {KeyValuePair}
+     * @returns {Future<KeyValuePair>|KeyValuePair}
      */
     asArrayElement: function () {
-        return this;
+        var pair = this;
+
+        if (!pair.value.isFuture()) {
+            return pair;
+        }
+
+        return pair.value
+            .asFuture()
+            .next(function (presentValue) {
+                return new KeyValuePair(pair.key, presentValue);
+            });
     },
 
+    /**
+     * Fetches the value of the key of the pair.
+     *
+     * @returns {Value}
+     */
     getKey: function () {
         return this.key;
     },
 
+    /**
+     * Fetches the value of the pair.
+     *
+     * @returns {Value}
+     */
     getValue: function () {
         return this.value;
     }

--- a/src/Load/Loader.js
+++ b/src/Load/Loader.js
@@ -67,7 +67,7 @@ module.exports = require('pauser')([
                 subOptions;
 
             // Always return a FutureValue, for a consistent interface regardless of synchronicity mode
-            return loader.valueFactory.createFuture(function (resolveFuture, rejectFuture) {
+            return loader.valueFactory.createFuture(function (resolveFuture, rejectFuture, nestCoroutine) {
                 /**
                  * Completes an unsuccessful module load
                  *
@@ -192,7 +192,8 @@ module.exports = require('pauser')([
                 try {
                     load(filePath, {
                         reject: reject,
-                        resolve: resolve
+                        resolve: resolve,
+                        nestCoroutine: nestCoroutine
                     }, module.getFilePath(), loader.valueFactory);
                 } catch (error) {
                     reject(error);

--- a/src/Load/Loader.js
+++ b/src/Load/Loader.js
@@ -13,14 +13,12 @@ module.exports = require('pauser')([
     require('microdash'),
     require('path'),
     require('phpcommon'),
-    require('../Value/Exit'),
     require('../Exception/LoadFailedException'),
     require('../Value')
 ], function (
     _,
     path,
     phpCommon,
-    ExitValue,
     LoadFailedException,
     Value
 ) {
@@ -89,7 +87,7 @@ module.exports = require('pauser')([
                 function succeedWith(moduleResult) {
                     done = true;
 
-                    if (moduleResult instanceof ExitValue) {
+                    if (moduleResult.getType() === 'exit') {
                         // When including a module, Engine.js will have resolved with an ExitValue
                         // rather than rejecting with it
                         failWith(moduleResult);

--- a/src/PHPState.js
+++ b/src/PHPState.js
@@ -49,6 +49,7 @@ module.exports = require('pauser')([
     require('./FFI/Value/Proxy/ProxyFactory'),
     require('./FFI/Value/Proxy/ProxyMemberFactory'),
     require('./FFI/Result'),
+    require('./FFI/Value/ResultValue'),
     require('./FFI/Stack/StackHooker'),
     require('./FFI/Export/UnwrapperRepository'),
     require('./FFI/Call/ValueCaller'),
@@ -148,6 +149,7 @@ module.exports = require('pauser')([
     FFIProxyFactory,
     FFIProxyMemberFactory,
     FFIResult,
+    FFIResultValue,
     FFIStackHooker,
     FFIUnwrapperRepository,
     FFIValueCaller,
@@ -528,6 +530,7 @@ module.exports = require('pauser')([
             ffiFactory = set('ffi_factory', new FFIFactory(
                 FFIAsyncObjectValue,
                 FFIPHPObject,
+                FFIResultValue,
                 FFIValueCoercer,
                 valueFactory,
                 referenceFactory,

--- a/src/Reference/AccessorReference.js
+++ b/src/Reference/AccessorReference.js
@@ -74,6 +74,13 @@ _.extend(AccessorReference.prototype, {
     /**
      * {@inheritdoc}
      */
+    hasReferenceSetter: function () {
+        return this.referenceSetter !== null;
+    },
+
+    /**
+     * {@inheritdoc}
+     */
     isDefined: function () {
         return true;
     },

--- a/src/Reference/Element.js
+++ b/src/Reference/Element.js
@@ -128,7 +128,7 @@ _.extend(ElementReference.prototype, {
         element.reference = element.referenceFactory.createReferenceSlot();
 
         if (element.value) {
-            element.reference.setValue(element.value);
+            element.reference.setValue(element.value).yieldSync();
             element.value = null; // This element now has a reference (to the slot) and not a value
         }
 

--- a/src/Reference/Property.js
+++ b/src/Reference/Property.js
@@ -147,7 +147,7 @@ _.extend(PropertyReference.prototype, {
         property.reference = property.referenceFactory.createReferenceSlot();
 
         if (property.value) {
-            property.reference.setValue(property.value);
+            property.reference.setValue(property.value).yieldSync();
             property.value = null; // This property now has a reference (to the slot) and not a value
         }
 

--- a/src/Reference/Reference.js
+++ b/src/Reference/Reference.js
@@ -43,6 +43,15 @@ _.extend(Reference.prototype, {
     },
 
     /**
+     * Returns a Future that will resolve to the native value of the PHP value being referred to.
+     *
+     * @returns {Future<*>}
+     */
+    asEventualNative: function () {
+        return this.getValue().asEventualNative();
+    },
+
+    /**
      * Formats the reference (which may not be defined) for display in stack traces etc.
      *
      * @returns {string}
@@ -103,6 +112,15 @@ _.extend(Reference.prototype, {
     },
 
     /**
+     * Determines whether this reference itself intercepts further reference assignments.
+     *
+     * @returns {boolean}
+     */
+    hasReferenceSetter: function () {
+        return false;
+    },
+
+    /**
      * Determines whether this reference is defined
      *
      * @returns {boolean}
@@ -147,6 +165,15 @@ _.extend(Reference.prototype, {
      * @returns {Value} Returns the value that was set
      */
     setValue: throwUnimplemented('setValue'),
+
+    /**
+     * Derives a promise of the PHP value being referred to (shared interface with Future).
+     *
+     * @returns {Promise<Value>}
+     */
+    toPromise: function () {
+        return this.getValue().toPromise();
+    },
 
     /**
      * Unsets the value of this reference.

--- a/src/Reference/Reference.js
+++ b/src/Reference/Reference.js
@@ -33,8 +33,8 @@ _.extend(Reference.prototype, {
     /**
      * Returns the value or reference of this reference, suitable for use as an array element.
      * Note that FutureValues will be returned unchanged ready to be awaited.
-     * ReferenceSlots will be returned unchanged as they represent a PHP reference
-     * and not something to resolve to an eventual value.
+     *
+     * PHP references will be represented as ReferenceElements instead.
      *
      * @returns {Reference|Value}
      */

--- a/src/Reference/ReferenceSlot.js
+++ b/src/Reference/ReferenceSlot.js
@@ -43,15 +43,6 @@ _.extend(ReferenceSlot.prototype, {
     /**
      * {@inheritdoc}
      */
-    asArrayElement: function () {
-        // Unlike other reference types, return ReferenceSlots unchanged as they represent
-        // an actual PHP reference and not a value.
-        return this;
-    },
-
-    /**
-     * {@inheritdoc}
-     */
     getForAssignment: function () {
         return this.getValue();
     },

--- a/src/Reference/StaticProperty.js
+++ b/src/Reference/StaticProperty.js
@@ -92,7 +92,7 @@ _.extend(StaticPropertyReference.prototype, {
         property.reference = property.referenceFactory.createReferenceSlot();
 
         if (property.value) {
-            property.reference.setValue(property.value);
+            property.reference.setValue(property.value).yieldSync();
             property.value = null; // This property now has a reference (to the slot) and not a value
         }
 

--- a/src/ScopeFactory.js
+++ b/src/ScopeFactory.js
@@ -13,10 +13,12 @@ var _ = require('microdash');
 
 /**
  * @param {class} ModuleScope
+ * @param {class} EngineScope
  * @param {class} LoadScope
  * @param {class} Scope
  * @param {class} NamespaceScope
  * @param {CallStack} callStack
+ * @param {ControlScope} controlScope
  * @param {Translator} translator
  * @param {SuperGlobalScope} superGlobalScope
  * @param {FunctionSpecFactory} functionSpecFactory
@@ -27,10 +29,12 @@ var _ = require('microdash');
  */
 function ScopeFactory(
     ModuleScope,
+    EngineScope,
     LoadScope,
     Scope,
     NamespaceScope,
     callStack,
+    controlScope,
     translator,
     superGlobalScope,
     functionSpecFactory,
@@ -46,6 +50,14 @@ function ScopeFactory(
      * @type {ClosureFactory}
      */
     this.closureFactory = null;
+    /**
+     * @type {ControlScope}
+     */
+    this.controlScope = controlScope;
+    /**
+     * @type {class}
+     */
+    this.EngineScope = EngineScope;
     /**
      * @type {FunctionSpecFactory}
      */
@@ -118,9 +130,27 @@ _.extend(ScopeFactory.prototype, {
             factory.valueFactory,
             factory.variableFactory,
             factory.referenceFactory,
+            factory.controlScope,
+            factory.controlScope.inCoroutine() ? factory.controlScope.getCoroutine() : null,
             currentClass || null,
             currentFunction || null,
             thisObject || null
+        );
+    },
+
+    /**
+     * Creates a new EngineScope.
+     *
+     * @param {Scope} effectiveScope
+     * @returns {EngineScope}
+     */
+    createEngineScope: function (effectiveScope) {
+        var factory = this;
+
+        return new factory.EngineScope(
+            effectiveScope,
+            factory.controlScope,
+            effectiveScope.getCoroutine()
         );
     },
 

--- a/src/Value.js
+++ b/src/Value.js
@@ -690,7 +690,10 @@ module.exports = require('pauser')([
         },
 
         /**
-         * Fetches a native representation of this value
+         * Fetches a native representation of this value. Note that if this value
+         * contains any references that return Future(Values), an error will be raised.
+         *
+         * @see .asEventualNative() if any descendant of this value may return any Future(Value)s.
          *
          * @returns {*}
          */
@@ -728,6 +731,13 @@ module.exports = require('pauser')([
         getStaticPropertyByName: function () {
             this.callStack.raiseTranslatedError(PHPError.E_ERROR, CLASS_NAME_NOT_VALID);
         },
+
+        /**
+         * Fetches the exit code for an exit value, if any, otherwise 0.
+         *
+         * @returns {number}
+         */
+        getStatus: throwUnimplemented('getStatus'),
 
         getType: function () {
             return this.type;

--- a/src/Value/Resource.js
+++ b/src/Value/Resource.js
@@ -19,7 +19,6 @@ var _ = require('microdash'),
     INVALID_FOREACH_ARGUMENT = 'core.invalid_foreach_argument',
     TRYING_TO_ACCESS_ARRAY_OFFSET = 'core.trying_to_access_array_offset',
     UNSUPPORTED_OPERAND_TYPES = 'core.unsupported_operand_types',
-    VALUE_NOT_CALLABLE = 'core.value_not_callable',
     Value = require('../Value').sync();
 
 /**
@@ -63,15 +62,6 @@ _.extend(ResourceValue.prototype, {
      */
     add: function () {
         this.callStack.raiseTranslatedError(PHPError.E_ERROR, UNSUPPORTED_OPERAND_TYPES);
-    },
-
-    /**
-     * {@inheritdoc}
-     */
-    call: function () {
-        this.callStack.raiseTranslatedError(PHPError.E_ERROR, VALUE_NOT_CALLABLE, {
-            'type': 'resource'
-        });
     },
 
     /**

--- a/src/Value/String.js
+++ b/src/Value/String.js
@@ -47,10 +47,10 @@ module.exports = require('pauser')([
 
     _.extend(StringValue.prototype, {
         /**
-         * Calls a function or static method based on the contents of the string
+         * Calls a function or static method based on the contents of the string.
          *
          * @param {Value[]} args
-         * @returns {Value}
+         * @returns {Future<Reference|Value>|Reference|Value}
          */
         call: function (args) {
             var classNameValue,
@@ -79,24 +79,21 @@ module.exports = require('pauser')([
         },
 
         /**
-         * Calls a static method of the class this string refers to
+         * Calls a static method of the class this string refers to.
          *
          * @param {StringValue} nameValue
          * @param {Value[]} args
          * @param {bool=} isForwarding eg. self::f() is forwarding, MyParentClass::f() is non-forwarding
-         * @returns {FutureValue}
+         * @returns {Future<Reference|Value>}
          */
         callStaticMethod: function (nameValue, args, isForwarding) {
             var value = this;
 
-            // Note that this may pause due to autoloading
-            return value.factory.createFuture(function (resolve, reject) {
-                value.globalNamespace.getClass(value.value)
-                    .next(function (classObject) {
-                        classObject.callMethod(nameValue.getNative(), args, null, null, null, !!isForwarding)
-                            .next(resolve, reject);
-                    }, reject);
-            });
+            // Note that this may pause due to autoloading.
+            return value.globalNamespace.getClass(value.value)
+                .next(function (classObject) {
+                    return classObject.callMethod(nameValue.getNative(), args, null, null, null, !!isForwarding);
+                });
         },
 
         /**
@@ -359,18 +356,17 @@ module.exports = require('pauser')([
          * Fetches the value of a constant from the class this string refers to
          *
          * @param {string} name
-         * @returns {FutureValue}
+         * @returns {Value}
          */
         getConstantByName: function (name) {
             var value = this;
 
             // Note that this may pause due to autoloading
-            return value.factory.createFuture(function (resolve, reject) {
-                value.globalNamespace.getClass(value.value)
-                    .next(function (classObject) {
-                        resolve(classObject.getConstantByName(name));
-                    }, reject);
-            });
+            return value.globalNamespace.getClass(value.value)
+                .next(function (classObject) {
+                    return classObject.getConstantByName(name);
+                })
+                .asValue();
         },
 
         /**

--- a/src/ValueFactory.js
+++ b/src/ValueFactory.js
@@ -672,7 +672,7 @@ module.exports = require('pauser')([
          */
         createFuture: function (executor) {
             var factory = this,
-                future = factory.futureFactory.createFuture(function (resolveFuture, rejectFuture) {
+                future = factory.futureFactory.createFuture(function (resolveFuture, rejectFuture, nestCoroutine) {
                     executor(
                         function resolve(result) {
                             // For FutureValues, we always want to coerce the eventual result to a Value
@@ -680,7 +680,8 @@ module.exports = require('pauser')([
                         },
                         function reject(error) {
                             return rejectFuture(error);
-                        }
+                        },
+                        nestCoroutine
                     );
                 });
 

--- a/src/builtin/opcodes/calculation.js
+++ b/src/builtin/opcodes/calculation.js
@@ -1352,9 +1352,11 @@ module.exports = function (internals) {
             var originalValue = reference.getValue(),
                 decrementedValue = originalValue.decrement();
 
-            reference.setValue(decrementedValue);
-
-            return originalValue;
+            return reference.setValue(decrementedValue)
+                .next(function () {
+                    return originalValue;
+                })
+                .asValue();
         },
 
         /**
@@ -1367,9 +1369,11 @@ module.exports = function (internals) {
             var originalValue = reference.getValue(),
                 incrementedValue = originalValue.increment();
 
-            reference.setValue(incrementedValue);
-
-            return originalValue;
+            return reference.setValue(incrementedValue)
+                .next(function () {
+                    return originalValue;
+                })
+                .asValue();
         },
 
         /**
@@ -1381,9 +1385,11 @@ module.exports = function (internals) {
         preDecrement: function (reference) {
             var decrementedValue = reference.getValue().decrement();
 
-            reference.setValue(decrementedValue);
-
-            return decrementedValue;
+            return reference.setValue(decrementedValue)
+                .next(function () {
+                    return decrementedValue;
+                })
+                .asValue();
         },
 
         /**
@@ -1395,9 +1401,11 @@ module.exports = function (internals) {
         preIncrement: function (reference) {
             var incrementedValue = reference.getValue().increment();
 
-            reference.setValue(incrementedValue);
-
-            return incrementedValue;
+            return reference.setValue(incrementedValue)
+                .next(function () {
+                    return incrementedValue;
+                })
+                .asValue();
         },
 
         /**

--- a/src/builtin/opcodes/calculation.js
+++ b/src/builtin/opcodes/calculation.js
@@ -16,6 +16,7 @@ var _ = require('microdash'),
     KeyReferencePair = require('../../KeyReferencePair'),
     KeyValuePair = require('../../KeyValuePair'),
     List = require('../../List'),
+    ReferenceElement = require('../../Element/ReferenceElement'),
 
     NO_PARENT_CLASS = 'core.no_parent_class',
     TICK_OPTION = 'tick';
@@ -157,11 +158,11 @@ module.exports = function (internals) {
 
         /**
          * Calls a PHP function where the name is known statically, returning its result
-         * as a Value if it returns by-value or as a ReferenceSlot if it returns by-reference.
+         * as a Value if it returns by-value or as a Reference if it returns by-reference.
          *
          * @param {string} name
          * @param {Reference[]|Value[]|Variable[]} argReferences
-         * @returns {ReferenceSlot|Value}
+         * @returns {Reference|Value}
          */
         callFunction: function (name, argReferences) {
             var namespaceScope = callStack.getCurrentNamespaceScope(),
@@ -172,12 +173,12 @@ module.exports = function (internals) {
 
         /**
          * Calls a PHP instance method where the name is known statically, returning its result
-         * as a Value if it returns by-value or as a ReferenceSlot if it returns by-reference.
+         * as a Value if it returns by-value or as a Reference if it returns by-reference.
          *
          * @param {Reference|Value|Variable} objectReference
          * @param {string} methodName
          * @param {Reference[]|Value[]|Variable[]} argReferences
-         * @returns {ReferenceSlot|Value}
+         * @returns {Reference|Value}
          */
         callInstanceMethod: function (objectReference, methodName, argReferences) {
             var objectValue = objectReference.getValue();
@@ -204,11 +205,11 @@ module.exports = function (internals) {
 
         /**
          * Calls a PHP function where the name is fetched dynamically, returning its result
-         * as a Value if it returns by-value or as a ReferenceSlot if it returns by-reference.
+         * as a Value if it returns by-value or as a Reference if it returns by-reference.
          *
          * @param {Reference|Value|Variable} nameReference
          * @param {Reference[]|Value[]|Variable[]} argReferences
-         * @returns {ReferenceSlot|Value}
+         * @returns {Reference|Value}
          */
         callVariableFunction: function (nameReference, argReferences) {
             // NB: Make sure we do not coerce argument references to their values,
@@ -218,12 +219,12 @@ module.exports = function (internals) {
 
         /**
          * Calls a method of an object where the name is fetched dynamically, returning its result
-         * as a Value if it returns by-value or as a ReferenceSlot if it returns by-reference.
+         * as a Value if it returns by-value or as a Reference if it returns by-reference.
          *
          * @param {Reference|Value|Variable} objectReference
          * @param {Reference|Value|Variable} methodNameReference
          * @param {Reference[]|Value[]|Variable[]} argReferences
-         * @returns {ReferenceSlot|Value}
+         * @returns {Reference|Value}
          */
         callVariableInstanceMethod: function (objectReference, methodNameReference, argReferences) {
             var objectValue = objectReference.getValue();
@@ -239,12 +240,12 @@ module.exports = function (internals) {
 
         /**
          * Calls a static method of a class where the name is fetched dynamically, returning its result
-         * as a Value if it returns by-value or as a ReferenceSlot if it returns by-reference.
+         * as a Value if it returns by-value or as a Reference if it returns by-reference.
          *
          * @param {Reference|Value|Variable} classNameReference
          * @param {Reference|Value|Variable} methodNameReference
          * @param {Reference[]|Value[]|Variable[]} argReferences
-         * @returns {ReferenceSlot|Value}
+         * @returns {Reference|Value}
          */
         callVariableStaticMethod: function (classNameReference, methodNameReference, argReferences) {
             var classNameValue = classNameReference.getValue(),
@@ -404,7 +405,7 @@ module.exports = function (internals) {
         createKeyReferencePair: function (keyReference, reference) {
             return new KeyReferencePair(
                 keyReference.getValue(),
-                // Reference may not be a ReferenceSlot, so we must ensure it like this
+                // Reference may not be a ReferenceSlot (if applicable), so we must ensure it like this
                 reference.getReference()
             );
         },
@@ -422,6 +423,20 @@ module.exports = function (internals) {
          */
         createList: function (elements) {
             return new List(valueFactory, flow, elements);
+        },
+
+        /**
+         * Fetches a ReferenceElement for the given reference. Note that if a value is given
+         * instead, an error will be thrown.
+         *
+         * Also note that an internal ReferenceSlot will be created if applicable.
+         *
+         * @param {Reference|Value|Variable} valueOrReference
+         * @returns {ReferenceElement}
+         * @throws {Error} Throws when a value is given instead of a reference
+         */
+        createReferenceElement: function (valueOrReference) {
+            return new ReferenceElement(valueOrReference.getReference());
         },
 
         createString: function (nativeValue) {
@@ -691,11 +706,11 @@ module.exports = function (internals) {
         },
 
         /**
-         * Fetches a ReferenceSlot for the given reference. Note that if a value is given
+         * Fetches a ReferenceSlot (if applicable) for the given reference. Note that if a value is given
          * instead, an error will be thrown.
          *
          * @param {Reference|Value|Variable} valueOrReference
-         * @returns {ReferenceSlot}
+         * @returns {Reference|ReferenceSlot}
          * @throws {Error} Throws when a value is given instead of a reference
          */
         getReference: function (valueOrReference) {

--- a/src/builtin/services/base.js
+++ b/src/builtin/services/base.js
@@ -21,9 +21,12 @@ var phpCommon = require('phpcommon'),
     ControlScope = require('../../Control/ControlScope'),
     ControlStructureOpcode = require('../../Core/Opcode/Opcode/ControlStructureOpcode'),
     ControlStructureOpcodeFetcher = require('../../Core/Opcode/Fetcher/ControlStructureOpcodeFetcher'),
+    Coroutine = require('../../Control/Coroutine'),
+    CoroutineFactory = require('../../Control/CoroutineFactory'),
     FFICall = require('../../FFI/Call'),
     Future = require('../../Control/Future'),
     FutureValue = require('../../Value/Future'),
+    HostScheduler = require('../../Control/HostScheduler'),
     LoopStructureOpcode = require('../../Core/Opcode/Opcode/LoopStructureOpcode'),
     LoopStructureOpcodeFetcher = require('../../Core/Opcode/Fetcher/LoopStructureOpcodeFetcher'),
     MethodPromoter = require('../../Class/MethodPromoter'),
@@ -97,8 +100,16 @@ module.exports = function (internals) {
             return new ControlScope();
         },
 
+        'coroutine_factory': function () {
+            return new CoroutineFactory(Coroutine, get(CALL_STACK));
+        },
+
         'function_signature_parser': function () {
             return new SignatureParser(get(VALUE_FACTORY));
+        },
+
+        'host_scheduler': function () {
+            return new HostScheduler();
         },
 
         'method_promoter': function () {

--- a/src/builtin/services/base.js
+++ b/src/builtin/services/base.js
@@ -179,6 +179,7 @@ module.exports = function (internals) {
         'value_provider': function () {
             return new ValueProvider(
                 get(VALUE_FACTORY),
+                get(FFI_FACTORY),
                 get(FLOW)
             );
         }

--- a/test/integration/bridge/syncObjectExportTest.js
+++ b/test/integration/bridge/syncObjectExportTest.js
@@ -223,7 +223,7 @@ EOS
             resultValue = phpEngine.execute();
 
         expect(resultValue.getType()).to.equal('object');
-        expect(resultValue.getClassName()).to.equal('MyClass');
+        expect(resultValue.getInternalValue().getClassName()).to.equal('MyClass');
         // Deliberately unwrap the object twice
         expect(resultValue.getNative()).to.equal(resultValue.getNative());
     });

--- a/test/integration/builtin/classes/Error/ParseErrorTest.js
+++ b/test/integration/builtin/classes/Error/ParseErrorTest.js
@@ -41,7 +41,7 @@ EOS
         resultValue = engine.execute();
 
         expect(resultValue.getType()).to.equal('object');
-        expect(resultValue.getClassName()).to.equal('ParseError');
+        expect(resultValue.getInternalValue().getClassName()).to.equal('ParseError');
         resultNativeError = resultValue.getNative();
         // Note that this coercion is defined by a custom unwrapper in src/builtin/classes/Error/ParseError.js
         expect(resultNativeError).to.be.an.instanceOf(PHPParseError);

--- a/test/integration/builtin/classes/ErrorTest.js
+++ b/test/integration/builtin/classes/ErrorTest.js
@@ -35,7 +35,7 @@ EOS
         resultValue = engine.execute();
 
         expect(resultValue.getType()).to.equal('object');
-        expect(resultValue.getClassName()).to.equal('Error');
+        expect(resultValue.getInternalValue().getClassName()).to.equal('Error');
         resultNativeError = resultValue.getNative();
         // Note that this coercion is defined by a custom unwrapper in src/builtin/interfaces/Throwable.js
         expect(resultNativeError).to.be.an.instanceOf(PHPFatalError);

--- a/test/integration/control/asyncModeTest.js
+++ b/test/integration/control/asyncModeTest.js
@@ -19,6 +19,7 @@ describe('Async control integration', function () {
     var call,
         callStack,
         controlFactory,
+        controlScope,
         environment,
         futureFactory,
         state;
@@ -28,6 +29,7 @@ describe('Async control integration', function () {
         state = environment.getState();
         callStack = state.getCallStack();
         controlFactory = state.getControlFactory();
+        controlScope = state.getControlScope();
         futureFactory = state.getFutureFactory();
 
         call = sinon.createStubInstance(Call);
@@ -375,6 +377,7 @@ describe('Async control integration', function () {
                 error.next(function () {
                     done();
                 });
+                controlScope.markPaused(error);
             }
 
             doResolve(21);

--- a/test/integration/errorHandling/fatalErrorHandlingTest.js
+++ b/test/integration/errorHandling/fatalErrorHandlingTest.js
@@ -87,8 +87,10 @@ EOS
             module = tools.asyncTranspile('/my/php_module.php', php),
             engine = module();
         engine.defineCoercingFunction('call_async', function (callback) {
-            return this.createFutureValue(function (resolve, reject) {
+            return this.createFutureValue(function (resolve, reject, nestCoroutine) {
                 setImmediate(function () {
+                    nestCoroutine(); // As this is a nested call.
+
                     callback().then(resolve, reject);
                 });
             });

--- a/test/integration/expressions/arrayLiteralTest.js
+++ b/test/integration/expressions/arrayLiteralTest.js
@@ -14,7 +14,7 @@ var expect = require('chai').expect,
     tools = require('../tools');
 
 describe('PHP array literal integration', function () {
-    it('should allow indexed elements to be defined with a reference to a variable', function () {
+    it('should allow indexed elements to be defined with a reference to a variable', async function () {
         var php = nowdoc(function () {/*<<<EOS
 <?php
 $myVar = 4;
@@ -25,9 +25,9 @@ $myVar = 27;
 return $myArray;
 EOS
 */;}), //jshint ignore:line
-            module = tools.syncTranspile('/path/to/my_module.php', php);
+            module = tools.asyncTranspile('/path/to/my_module.php', php);
 
-        expect(module().execute().getNative()).to.deep.equal([
+        expect((await module().execute()).getNative()).to.deep.equal([
             21,
             4,
             27
@@ -58,7 +58,7 @@ EOS
         ]);
     });
 
-    it('should allow associative elements to be defined with a reference to a variable', function () {
+    it('should allow associative elements to be defined with a reference to a variable', async function () {
         var php = nowdoc(function () {/*<<<EOS
 <?php
 $myVar = 4;
@@ -69,16 +69,16 @@ $myVar = 27;
 return $myArray;
 EOS
 */;}), //jshint ignore:line
-            module = tools.syncTranspile('/path/to/my_module.php', php);
+            module = tools.asyncTranspile('/path/to/my_module.php', php);
 
-        expect(module().execute().getNative()).to.deep.equal({
+        expect((await module().execute()).getNative()).to.deep.equal({
             0: 21,
             1: 4,
             'myRef': 27
         });
     });
 
-    it('should allow elements to be defined with the value of a property', function () {
+    it('should allow elements to be defined with the value of a property', async function () {
         var php = nowdoc(function () {/*<<<EOS
 <?php
 class MyClass {
@@ -91,15 +91,15 @@ $myArray = [21, $myObject->myProp];
 return $myArray;
 EOS
 */;}), //jshint ignore:line
-            module = tools.syncTranspile('/path/to/my_module.php', php);
+            module = tools.asyncTranspile('/path/to/my_module.php', php);
 
-        expect(module().execute().getNative()).to.deep.equal([
+        expect((await module().execute()).getNative()).to.deep.equal([
             21,
             101
         ]);
     });
 
-    it('should allow elements to be defined with the key "length"', function () {
+    it('should allow elements to be defined with the key "length"', async function () {
         var php = nowdoc(function () {/*<<<EOS
 <?php
 
@@ -108,9 +108,9 @@ $myArray = ['length' => 21, 101];
 return $myArray;
 EOS
 */;}), //jshint ignore:line
-            module = tools.syncTranspile('/path/to/my_module.php', php);
+            module = tools.asyncTranspile('/path/to/my_module.php', php);
 
-        expect(module().execute().getNative()).to.deep.equal({
+        expect((await module().execute()).getNative()).to.deep.equal({
             length: 21,
             0: 101
         });

--- a/test/integration/expressions/functionCallTest.js
+++ b/test/integration/expressions/functionCallTest.js
@@ -353,4 +353,78 @@ EOS
 */;}) //jshint ignore:line
         );
     });
+
+    it('should raise a fatal error on uncallable values', function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+$result = [];
+
+$myBooleanFuncName = true;
+
+try {
+    $myBooleanFuncName(21);
+} catch (Throwable $throwable) {
+    $result['boolean value'] = $throwable::class .
+        ': ' .
+        $throwable->getMessage() .
+        ' @ ' .
+        $throwable->getFile() .
+        ':' .
+        $throwable->getLine();
+}
+
+$myFloatFuncName = 123.456;
+
+try {
+    $myFloatFuncName(21);
+} catch (Throwable $throwable) {
+    $result['float value'] = $throwable::class .
+        ': ' .
+        $throwable->getMessage() .
+        ' @ ' .
+        $throwable->getFile() .
+        ':' .
+        $throwable->getLine();
+}
+
+$myIntFuncName = 27;
+
+try {
+    $myIntFuncName(21);
+} catch (Throwable $throwable) {
+    $result['int value'] = $throwable::class .
+        ': ' .
+        $throwable->getMessage() .
+        ' @ ' .
+        $throwable->getFile() .
+        ':' .
+        $throwable->getLine();
+}
+
+$myNullFuncName = null;
+
+try {
+    $myNullFuncName(21);
+} catch (Throwable $throwable) {
+    $result['null value'] = $throwable::class .
+        ': ' .
+        $throwable->getMessage() .
+        ' @ ' .
+        $throwable->getFile() .
+        ':' .
+        $throwable->getLine();
+}
+
+return $result;
+EOS
+*/;}), //jshint ignore:line
+            module = tools.syncTranspile('/path/to/my_module.php', php);
+
+        expect(module().execute().getNative()).to.deep.equal({
+            'boolean value': 'Error: Value of type boolean is not callable @ /path/to/my_module.php:7',
+            'float value': 'Error: Value of type float is not callable @ /path/to/my_module.php:21',
+            'int value': 'Error: Value of type int is not callable @ /path/to/my_module.php:35',
+            'null value': 'Error: Value of type null is not callable @ /path/to/my_module.php:49'
+        });
+    });
 });

--- a/test/integration/ffi/api/public/globals/globalAccessorTest.js
+++ b/test/integration/ffi/api/public/globals/globalAccessorTest.js
@@ -1,0 +1,92 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    nowdoc = require('nowdoc'),
+    tools = require('../../../../tools');
+
+describe('PHP public FFI global accessors integration', function () {
+    it('should support defining a global accessor whose value can be set asynchronously', async function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+$myAccessor = 21;
+
+return $myAccessor + 6;
+EOS
+*/;}), //jshint ignore:line
+            module = tools.asyncTranspile('/path/to/my_module.php', php),
+            engine = module(),
+            myValue;
+        engine.defineGlobalAccessor(
+            'myAccessor',
+            function () {
+                return myValue;
+            },
+            function (newValue) {
+                return engine.createFFIResult(
+                    function () {
+                        throw new Error('This test should run in async mode and use the async callback');
+                    },
+                    function () {
+                        return new Promise(function (resolve) {
+                            myValue = newValue;
+                            resolve();
+                        });
+                    }
+                );
+            }
+        );
+
+        expect((await engine.execute()).getNative()).to.equal(27);
+    });
+
+    it('should support defining a global accessor whose reference can be set', async function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+$result = [];
+
+$myAccessor =& $myVar;
+$myVar = 21;
+$result['after assigning to variable'] = $myAccessor . ' [from module first]';
+
+$myAccessor = 101;
+$result['after assigning to accessor'] = $myAccessor . ' [from module second]';
+
+return $result;
+EOS
+*/;}), //jshint ignore:line
+            module = tools.asyncTranspile('/path/to/my_module.php', php),
+            engine = module(),
+            myReference;
+        engine.defineGlobalAccessor(
+            'myAccessor',
+            // Define a value getter.
+            function () {
+                return myReference.getValue().next(function (resolvedValue) {
+                    return resolvedValue.getNative() + ' [from getter]';
+                });
+            },
+            // Define a value setter.
+            function (newValue) {
+                myReference.setValue(newValue);
+            },
+            // Define a setter for further reference-assignments.
+            function (reference) {
+                myReference = reference;
+            }
+        );
+
+        expect((await engine.execute()).getNative()).to.deep.equal({
+            'after assigning to variable': '21 [from getter] [from module first]',
+            'after assigning to accessor': '101 [from getter] [from module second]'
+        });
+    });
+});

--- a/test/integration/ffi/api/public/globals/globalVariableTest.js
+++ b/test/integration/ffi/api/public/globals/globalVariableTest.js
@@ -1,0 +1,29 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    nowdoc = require('nowdoc'),
+    tools = require('../../../../tools');
+
+describe('PHP public FFI global variables integration', function () {
+    it('should support defining a global variable from a native value', async function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+return $myGlobal + 6;
+EOS
+*/;}), //jshint ignore:line
+            module = tools.asyncTranspile('/path/to/my_module.php', php),
+            engine = module();
+        engine.defineGlobal('myGlobal', 21);
+
+        expect((await engine.execute()).getNative()).to.equal(27);
+    });
+});

--- a/test/integration/operators/castTest.js
+++ b/test/integration/operators/castTest.js
@@ -186,15 +186,16 @@ EOS
 */;}), //jshint ignore:line
             module = tools.syncTranspile('/path/to/my_module.php', php),
             engine = module(),
-            value = engine.execute();
+            value = engine.execute(),
+            internalValue = value.getInternalValue();
 
-        expect(value.getElementByIndex(0).getValue().getType()).to.equal('object');
-        expect(value.getElementByIndex(0).getValue().getClassName()).to.equal('stdClass');
-        expect(value.getElementByIndex(0).getValue().getNative().scalar).to.equal(21);
-        expect(value.getElementByIndex(1).getValue().getType()).to.equal('object');
-        expect(value.getElementByIndex(1).getValue().getClassName()).to.equal('stdClass');
-        expect(value.getElementByIndex(1).getValue().getNative().myEl).to.equal('my value');
-        expect(value.getElementByIndex(2).getValue().getClassName()).to.equal('MyClass');
+        expect(internalValue.getElementByIndex(0).getValue().getType()).to.equal('object');
+        expect(internalValue.getElementByIndex(0).getValue().getClassName()).to.equal('stdClass');
+        expect(internalValue.getElementByIndex(0).getValue().getNative().scalar).to.equal(21);
+        expect(internalValue.getElementByIndex(1).getValue().getType()).to.equal('object');
+        expect(internalValue.getElementByIndex(1).getValue().getClassName()).to.equal('stdClass');
+        expect(internalValue.getElementByIndex(1).getValue().getNative().myEl).to.equal('my value');
+        expect(internalValue.getElementByIndex(2).getValue().getClassName()).to.equal('MyClass');
     });
 
     it('should support the (string) cast', function () {

--- a/test/integration/operators/decrementTest.js
+++ b/test/integration/operators/decrementTest.js
@@ -14,7 +14,7 @@ var expect = require('chai').expect,
     tools = require('../tools');
 
 describe('PHP decrement "--" operator integration', function () {
-    it('should be able to decrement a variable or variable reference', function () {
+    it('should be able to decrement a variable or variable reference', async function () {
         var php = nowdoc(function () {/*<<<EOS
 <?php
 
@@ -34,10 +34,10 @@ $result['final ref'] = $myRef;
 return $result;
 EOS
 */;}), //jshint ignore:line
-            module = tools.syncTranspile('/path/to/my_module.php', php),
+            module = tools.asyncTranspile('/path/to/my_module.php', php),
             engine = module();
 
-        expect(engine.execute().getNative()).to.deep.equal({
+        expect((await engine.execute()).getNative()).to.deep.equal({
             'initial number': 21,
             'initial ref': 21,
             'number post-dec': 21, // Post-decrement won't have been able to update the property yet
@@ -49,7 +49,7 @@ EOS
         });
     });
 
-    it('should be able to decrement an instance property', function () {
+    it('should be able to decrement an instance property', async function () {
         var php = nowdoc(function () {/*<<<EOS
 <?php
 
@@ -69,10 +69,10 @@ $result[] = $object->myProp;
 return $result;
 EOS
 */;}), //jshint ignore:line
-            module = tools.syncTranspile('/path/to/my_module.php', php),
+            module = tools.asyncTranspile('/path/to/my_module.php', php),
             engine = module();
 
-        expect(engine.execute().getNative()).to.deep.equal([
+        expect((await engine.execute()).getNative()).to.deep.equal([
             21,
             21, // Post-decrement won't have been able to update the property yet
             19, // Previous post-decrement plus this pre-decrement
@@ -80,7 +80,7 @@ EOS
         ]);
     });
 
-    it('should be able to decrement a static property', function () {
+    it('should be able to decrement a static property', async function () {
         var php = nowdoc(function () {/*<<<EOS
 <?php
 
@@ -99,10 +99,10 @@ $result[] = MyClass::$myStaticProp;
 return $result;
 EOS
 */;}), //jshint ignore:line
-            module = tools.syncTranspile('/path/to/my_module.php', php),
+            module = tools.asyncTranspile('/path/to/my_module.php', php),
             engine = module();
 
-        expect(engine.execute().getNative()).to.deep.equal([
+        expect((await engine.execute()).getNative()).to.deep.equal([
             21,
             21, // Post-decrement won't have been able to update the property yet
             19, // Previous post-decrement plus this pre-decrement

--- a/test/integration/reentrancyTest.js
+++ b/test/integration/reentrancyTest.js
@@ -49,9 +49,7 @@ EOS
         expect((await engine.execute()).getNative()).to.deep.equal({
             'trace': nowdoc(function () {/*<<<EOS
 #0 /path/to/my_module.php(10): getTrace()
-#1 /path/to/my_module.php(3): ()
-#2 /path/to/my_module.php(3): do_pause_if_needed()
-#3 {main}
+#1 {main}
 EOS
 */;}), //jshint ignore:line
         });
@@ -89,5 +87,294 @@ EOS
 
         // Call the second closure
         expect(await exportedClosures.second()).to.equal('my result');
+    });
+
+    it('should support resuming an earlier pause while a later one is in effect using exported closures', async function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+$firstClosure = function () {
+    do_first_pause();
+
+    return 'my first result';
+};
+
+$secondClosure = function () {
+    do_second_pause();
+
+    return 'my second result';
+};
+
+return [
+    'first' => $firstClosure,
+    'second' => $secondClosure
+];
+EOS
+*/;}),//jshint ignore:line
+            module = tools.asyncTranspile('/path/to/my_module.php', php),
+            engine = module(),
+            exportedClosures,
+            firstPromise,
+            secondPromise,
+            resolveFirstPause,
+            resolveSecondPause;
+        engine.defineCoercingFunction('do_first_pause', function () {
+            return this.createFutureValue(function (resolve) {
+                resolveFirstPause = resolve;
+                // Leave the future unresolved so the engine will be paused...
+            });
+        });
+        engine.defineCoercingFunction('do_second_pause', function () {
+            return this.createFutureValue(function (resolve) {
+                resolveSecondPause = resolve;
+                // Leave the future unresolved so the engine will be paused...
+            });
+        });
+        exportedClosures = (await engine.execute()).getNative();
+        // Call the first closure, which will pause indefinitely. Whilst paused...
+        firstPromise = exportedClosures.first();
+        // Call the second closure, which will also pause indefinitely. Whilst paused...
+        secondPromise = exportedClosures.second();
+
+        // Go back and resume the first pause while the second is also in effect.
+        resolveFirstPause();
+        expect(await firstPromise).to.equal('my first result');
+        // Finally go back and resume the second pause.
+        resolveSecondPause();
+        expect(await secondPromise).to.equal('my second result');
+    });
+
+    it('should support resuming an earlier pause while a later one is in effect using instance methods of exported object', async function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+class MyClass
+{
+    public function firstMethod()
+    {
+        do_first_pause();
+
+        return 'my first result';
+    }
+
+    public function secondMethod()
+    {
+        do_second_pause();
+
+        return 'my second result';
+    }
+}
+
+return new MyClass;
+EOS
+*/;}),//jshint ignore:line
+            module = tools.asyncTranspile('/path/to/my_module.php', php),
+            engine = module(),
+            exportedObject,
+            firstPromise,
+            secondPromise,
+            resolveFirstPause,
+            resolveSecondPause;
+        engine.defineCoercingFunction('do_first_pause', function () {
+            return this.createFutureValue(function (resolve) {
+                resolveFirstPause = resolve;
+                // Leave the future unresolved so the engine will be paused...
+            });
+        });
+        engine.defineCoercingFunction('do_second_pause', function () {
+            return this.createFutureValue(function (resolve) {
+                resolveSecondPause = resolve;
+                // Leave the future unresolved so the engine will be paused...
+            });
+        });
+        exportedObject = (await engine.execute()).getNative();
+        // Call the first method, which will pause indefinitely. Whilst paused...
+        firstPromise = exportedObject.firstMethod();
+        // Call the second method, which will also pause indefinitely. Whilst paused...
+        secondPromise = exportedObject.secondMethod();
+
+        // Go back and resume the first pause while the second is also in effect.
+        resolveFirstPause();
+        expect(await firstPromise).to.equal('my first result');
+        // Finally go back and resume the second pause.
+        resolveSecondPause();
+        expect(await secondPromise).to.equal('my second result');
+    });
+
+    it('should support resuming an earlier pause while a later one is in effect using methods of imported JSObject', async function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+$myCallback = function ($myValue) {
+    return $myValue . ' (via callback)';
+};
+
+// Wrap access to the methods otherwise the underlying JS object will simply be returned to JS-land.
+return [
+    'first' => function () use ($myObject, $myCallback) {
+        return $myObject->firstMethod($myCallback);
+    },
+    'second' => function () use ($myObject, $myCallback) {
+        return $myObject->secondMethod($myCallback);
+    }
+];
+EOS
+*/;}),//jshint ignore:line
+            module = tools.asyncTranspile('/path/to/my_module.php', php),
+            engine = module(),
+            exportedObject,
+            firstPromise,
+            secondPromise,
+            resolveFirstPause,
+            resolveSecondPause,
+            waitFor = 2,
+            resolveReady,
+            oneReady = function () {
+                waitFor--;
+
+                if (waitFor === 0) {
+                    resolveReady();
+                }
+            },
+            readyPromise = new Promise(function (resolve) {
+                resolveReady = resolve;
+            });
+        engine.defineGlobal('myObject', {
+            firstMethod: function (myCallback) {
+                return engine.createFFIResult(
+                    function () {
+                        throw new Error('This test should run in async mode and use the async callback');
+                    },
+                    function () {
+                        return new Promise(function (resolve) {
+                            resolveFirstPause = resolve;
+                            // Promises always settle in a microtask so there will be a pause...
+
+                            oneReady();
+                        }).then(function () {
+                            return myCallback('my first result');
+                        });
+                    }
+                );
+            },
+            secondMethod: function (myCallback) {
+                return engine.createFFIResult(
+                    function () {
+                        throw new Error('This test should run in async mode and use the async callback');
+                    },
+                    function () {
+                        return new Promise(function (resolve) {
+                            resolveSecondPause = resolve;
+                            // Promises always settle in a microtask so there will be a pause...
+
+                            oneReady();
+                        }).then(function () {
+                            return myCallback('my second result');
+                        });
+                    }
+                );
+            }
+        });
+        exportedObject = (await engine.execute()).getNative();
+        // Call the first method, which will pause indefinitely. Whilst paused...
+        firstPromise = exportedObject.first();
+        // Call the second method, which will also pause indefinitely. Whilst paused...
+        secondPromise = exportedObject.second();
+        // Wait for both coroutines to finish pausing fully.
+        await readyPromise;
+
+        // Go back and resume the first pause while the second is also in effect.
+        resolveFirstPause();
+        expect(await firstPromise).to.equal('my first result (via callback)');
+        // Finally go back and resume the second pause.
+        resolveSecondPause();
+        expect(await secondPromise).to.equal('my second result (via callback)');
+    });
+
+    it('should support resuming an earlier pause while a later one is in effect using imported functions (JSObject-wrapped)', async function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+$myCallback = function ($myValue) {
+    return $myValue;
+};
+
+return [
+    'first' => function () use ($firstFunction, $myCallback) {
+        return $firstFunction($myCallback);
+    },
+    'second' => function () use ($secondFunction, $myCallback) {
+        return $secondFunction($myCallback);
+    }
+];
+EOS
+*/;}),//jshint ignore:line
+            module = tools.asyncTranspile('/path/to/my_module.php', php),
+            engine = module(),
+            exportedObject,
+            firstPromise,
+            secondPromise,
+            resolveFirstPause,
+            resolveSecondPause,
+            waitFor = 2,
+            resolveReady,
+            oneReady = function () {
+                waitFor--;
+
+                if (waitFor === 0) {
+                    resolveReady();
+                }
+            },
+            readyPromise = new Promise(function (resolve) {
+                resolveReady = resolve;
+            });
+        engine.defineGlobal('firstFunction', function (myCallback) {
+            return engine.createFFIResult(
+                function () {
+                    throw new Error('This test should run in async mode and use the async callback');
+                },
+                function () {
+                    return new Promise(function (resolve) {
+                        resolveFirstPause = resolve;
+                        // Promises always settle in a microtask so there will be a pause...
+
+                        oneReady();
+                    }).then(function () {
+                        return myCallback('my first result');
+                    });
+                }
+            );
+        });
+        engine.defineGlobal('secondFunction', function (myCallback) {
+            return engine.createFFIResult(
+                function () {
+                    throw new Error('This test should run in async mode and use the async callback');
+                },
+                function () {
+                    return new Promise(function (resolve) {
+                        resolveSecondPause = resolve;
+                        // Promises always settle in a microtask so there will be a pause...
+
+                        oneReady();
+                    }).then(function () {
+                        return myCallback('my second result');
+                    });
+                }
+            );
+        });
+        exportedObject = (await engine.execute()).getNative();
+        // Call the first method, which will pause indefinitely. Whilst paused...
+        firstPromise = exportedObject.first();
+        // Call the second method, which will also pause indefinitely. Whilst paused...
+        secondPromise = exportedObject.second();
+        // Wait for both coroutines to finish pausing fully.
+        await readyPromise;
+
+        // Go back and resume the first pause while the second is also in effect.
+        resolveFirstPause();
+        expect(await firstPromise).to.equal('my first result');
+        // Finally go back and resume the second pause.
+        resolveSecondPause();
+        expect(await secondPromise).to.equal('my second result');
     });
 });

--- a/test/integration/reentrancyTest.js
+++ b/test/integration/reentrancyTest.js
@@ -1,0 +1,93 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    nowdoc = require('nowdoc'),
+    tools = require('./tools');
+
+describe('PHP reentrancy integration', function () {
+    it('should support re-executing a module during a pause', async function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+do_pause_if_needed();
+
+function getTrace() {
+    return (new Exception)->getTraceAsString();
+}
+
+return [
+    'trace' => getTrace()
+];
+EOS
+*/;}),//jshint ignore:line
+            module = tools.asyncTranspile('/path/to/my_module.php', php),
+            engine = module(),
+            paused = false;
+        engine.defineCoercingFunction('do_pause_if_needed', function () {
+            if (paused) {
+                return;
+            }
+
+            paused = true;
+
+            return this.createFutureValue(function () {
+                // Leave the future unresolved so the engine will be paused...
+            });
+        });
+        // Perform the initial execution, which will pause indefinitely. Whilst paused...
+        engine.execute();
+
+        expect((await engine.execute()).getNative()).to.deep.equal({
+            'trace': nowdoc(function () {/*<<<EOS
+#0 /path/to/my_module.php(10): getTrace()
+#1 /path/to/my_module.php(3): ()
+#2 /path/to/my_module.php(3): do_pause_if_needed()
+#3 {main}
+EOS
+*/;}), //jshint ignore:line
+        });
+    });
+
+    it('should support calling into an exported closure while one is paused', async function () {
+        var php = nowdoc(function () {/*<<<EOS
+<?php
+
+$firstClosure = function () {
+    do_pause();
+};
+
+$secondClosure = function () {
+    return 'my result';
+};
+
+return [
+    'first' => $firstClosure,
+    'second' => $secondClosure
+];
+EOS
+*/;}),//jshint ignore:line
+            module = tools.asyncTranspile('/path/to/my_module.php', php),
+            engine = module(),
+            exportedClosures;
+        engine.defineCoercingFunction('do_pause', function () {
+            return this.createFutureValue(function () {
+                // Leave the future unresolved so the engine will be paused...
+            });
+        });
+        exportedClosures = (await engine.execute()).getNative();
+        // Call the first closure, which will pause indefinitely. Whilst paused...
+        exportedClosures.first();
+
+        // Call the second closure
+        expect(await exportedClosures.second()).to.equal('my result');
+    });
+});

--- a/test/integration/statements/doWhileLoopTest.js
+++ b/test/integration/statements/doWhileLoopTest.js
@@ -39,7 +39,7 @@ EOS
         ]);
     });
 
-    it('should be able to loop in async mode with pauses', function () {
+    it('should be able to loop in async mode with pauses', async function () {
         var php = nowdoc(function () {/*<<<EOS
 <?php
 $result = [];
@@ -67,12 +67,10 @@ EOS
             };
         });
 
-        return engine.execute().then(function (resultValue) {
-            expect(resultValue.getNative()).to.deep.equal([
-                '[5]',
-                '[4]',
-                '[3]'
-            ]);
-        });
+        expect((await engine.execute()).getNative()).to.deep.equal([
+            '[5]',
+            '[4]',
+            '[3]'
+        ]);
     });
 });

--- a/test/integration/statements/whileLoopTest.js
+++ b/test/integration/statements/whileLoopTest.js
@@ -78,7 +78,7 @@ EOS
         ]);
     });
 
-    it('should be able to loop in async mode with pauses', function () {
+    it('should be able to loop in async mode with pauses', async function () {
         var php = nowdoc(function () {/*<<<EOS
 <?php
 $result = [];
@@ -106,16 +106,14 @@ EOS
             };
         });
 
-        return engine.execute().then(function (resultValue) {
-            expect(resultValue.getNative()).to.deep.equal([
-                '[5]',
-                '[4]',
-                '[3]'
-            ]);
-        });
+        expect((await engine.execute()).getNative()).to.deep.equal([
+            '[5]',
+            '[4]',
+            '[3]'
+        ]);
     });
 
-    it('should be able to nest loops in async mode with pauses', function () {
+    it('should be able to nest loops in async mode with pauses', async function () {
         var php = nowdoc(function () {/*<<<EOS
 <?php
 $result = [];
@@ -151,19 +149,17 @@ EOS
             };
         });
 
-        return engine.execute().then(function (resultValue) {
-            expect(resultValue.getNative()).to.deep.equal([
-                '[5]',
-                '[[3]]',
-                '[[2]]',
-                '[4]',
-                '[[3]]',
-                '[[2]]',
-                '[3]',
-                '[[3]]',
-                '[[2]]'
-            ]);
-        });
+        expect((await engine.execute()).getNative()).to.deep.equal([
+            '[5]',
+            '[[3]]',
+            '[[2]]',
+            '[4]',
+            '[[3]]',
+            '[[2]]',
+            '[3]',
+            '[[3]]',
+            '[[2]]'
+        ]);
     });
 
     it('should support fetching the condition from accessor returning future in async mode', async function () {

--- a/test/unit/ClassAutoloaderTest.js
+++ b/test/unit/ClassAutoloaderTest.js
@@ -10,6 +10,7 @@
 'use strict';
 
 var expect = require('chai').expect,
+    queueMicrotask = require('core-js-pure/actual/queue-microtask'),
     sinon = require('sinon'),
     tools = require('./tools'),
     ClassAutoloader = require('../../src/ClassAutoloader').sync(),
@@ -38,12 +39,12 @@ describe('ClassAutoloader', function () {
     });
 
     describe('autoloadClass()', function () {
-        it('should await an autoloader function if it returns a FutureValue', async function () {
+        it('should await an autoloader function if it returns a Future', async function () {
             var autoloadCallableValue = sinon.createStubInstance(Value),
                 otherAutoloadCallableValue = sinon.createStubInstance(Value);
             autoloadCallableValue.call
-                .returns(valueFactory.createFuture(function (resolve) {
-                    setImmediate(function () {
+                .returns(futureFactory.createFuture(function (resolve) {
+                    queueMicrotask(function () {
                         globalNamespace.hasClass
                             .withArgs('My\\Stuff\\MyClass')
                             .returns(true);
@@ -66,8 +67,8 @@ describe('ClassAutoloader', function () {
             var firstAutoloadCallableValue = sinon.createStubInstance(Value),
                 secondAutoloadCallableValue = sinon.createStubInstance(Value);
             firstAutoloadCallableValue.call
-                .returns(valueFactory.createFuture(function (resolve) {
-                    setImmediate(function () {
+                .returns(futureFactory.createFuture(function (resolve) {
+                    queueMicrotask(function () {
                         globalNamespace.hasClass
                             .withArgs('My\\Stuff\\MyClass')
                             .returns(true);
@@ -99,7 +100,7 @@ describe('ClassAutoloader', function () {
 
             resultValue = classAutoloader.autoloadClass('My\\Stuff\\MyClass');
 
-            // Note that the result of an autoloader function is not checked, however if a FutureValue
+            // Note that the result of an autoloader function is not checked, however if a Future(Value)
             // is returned then we will need to await it.
             expect(resultValue.getType()).to.equal('string');
             expect(resultValue.getNative()).to.equal('my result');

--- a/test/unit/Control/ControlScopeTest.js
+++ b/test/unit/Control/ControlScopeTest.js
@@ -1,0 +1,316 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpCommon = require('phpcommon'),
+    sinon = require('sinon'),
+    tools = require('../tools'),
+    ControlScope = require('../../../src/Control/ControlScope'),
+    Coroutine = require('../../../src/Control/Coroutine'),
+    CoroutineFactory = require('../../../src/Control/CoroutineFactory'),
+    Exception = phpCommon.Exception,
+    Pause = require('../../../src/Control/Pause');
+
+describe('ControlScope', function () {
+    var controlScope,
+        coroutineFactory,
+        createdCoroutine,
+        state;
+
+    beforeEach(function () {
+        state = tools.createIsolatedState();
+        coroutineFactory = sinon.createStubInstance(CoroutineFactory);
+        createdCoroutine = null;
+
+        coroutineFactory.createCoroutine.callsFake(function () {
+            createdCoroutine = sinon.createStubInstance(Coroutine);
+
+            return createdCoroutine;
+        });
+
+        controlScope = new ControlScope();
+        controlScope.setCoroutineFactory(coroutineFactory);
+    });
+
+    describe('enterCoroutine()', function () {
+        describe('when there is no current Coroutine', function () {
+            it('should enter a new Coroutine', function () {
+                var coroutine = controlScope.enterCoroutine();
+
+                expect(coroutineFactory.createCoroutine).to.have.been.calledOnce;
+                expect(controlScope.getCoroutine()).to.equal(createdCoroutine);
+                expect(coroutine).to.equal(createdCoroutine);
+            });
+        });
+
+        describe('when there is a current Coroutine', function () {
+            var previousCoroutine;
+
+            beforeEach(function () {
+                previousCoroutine = controlScope.enterCoroutine();
+
+                coroutineFactory.createCoroutine.resetHistory();
+            });
+
+            it('should enter a new Coroutine', function () {
+                var coroutine = controlScope.enterCoroutine();
+
+                expect(coroutineFactory.createCoroutine).to.have.been.calledOnce;
+                expect(controlScope.getCoroutine()).to.equal(createdCoroutine);
+                expect(coroutine).to.equal(createdCoroutine);
+            });
+
+            it('should suspend the previous Coroutine', function () {
+                controlScope.enterCoroutine();
+
+                expect(previousCoroutine.suspend).to.have.been.calledOnce;
+            });
+        });
+
+        describe('when the next Coroutine has been marked for nesting', function () {
+            var doCreateAndNest,
+                previousCoroutine;
+
+            beforeEach(function () {
+                doCreateAndNest = function () {
+                    previousCoroutine = controlScope.enterCoroutine();
+                    coroutineFactory.createCoroutine.resetHistory();
+
+                    controlScope.nestCoroutine();
+                };
+            });
+
+            it('should not create a new Coroutine', function () {
+                doCreateAndNest();
+
+                controlScope.enterCoroutine();
+
+                expect(coroutineFactory.createCoroutine).not.to.have.been.called;
+            });
+
+            it('should keep the previous Coroutine as current', function () {
+                doCreateAndNest();
+
+                controlScope.enterCoroutine();
+
+                expect(controlScope.getCoroutine()).to.equal(previousCoroutine);
+            });
+
+            it('should return the previous Coroutine', function () {
+                doCreateAndNest();
+
+                expect(controlScope.enterCoroutine()).to.equal(previousCoroutine);
+            });
+
+            it('should throw when there is no current Coroutine', function () {
+                controlScope.nestCoroutine();
+
+                expect(function () {
+                    controlScope.enterCoroutine();
+                }).to.throw(
+                    Exception,
+                    'ControlScope.enterCoroutine() :: Unable to nest - no coroutine is active'
+                );
+            });
+        });
+    });
+
+    describe('getCoroutine()', function () {
+        it('should return the current Coroutine', function () {
+            var coroutine = controlScope.enterCoroutine();
+
+            expect(controlScope.getCoroutine()).to.equal(coroutine);
+        });
+
+        it('should raise an Exception when there is no current Coroutine', function () {
+            expect(function () {
+                controlScope.getCoroutine();
+            }).to.throw(
+                Exception,
+                'ControlScope.getCoroutine() :: Invalid state - no coroutine is active'
+            );
+        });
+    });
+
+    describe('inCoroutine()', function () {
+        it('should return true when there is a current Coroutine', function () {
+            controlScope.enterCoroutine();
+
+            expect(controlScope.inCoroutine()).to.be.true;
+        });
+
+        it('should return false when there is no current Coroutine', function () {
+            expect(controlScope.inCoroutine()).to.be.false;
+        });
+    });
+
+    describe('isNestingCoroutine()', function () {
+        it('should return true when nesting the next Coroutine', function () {
+            controlScope.nestCoroutine();
+
+            expect(controlScope.isNestingCoroutine()).to.be.true;
+        });
+
+        it('should return false when not nesting the next Coroutine', function () {
+            expect(controlScope.isNestingCoroutine()).to.be.false;
+        });
+    });
+
+    describe('isPausing()', function () {
+        var pause;
+
+        beforeEach(function () {
+            pause = sinon.createStubInstance(Pause);
+        });
+
+        it('should return true when there is a Pause taking effect', function () {
+            controlScope.markPausing(pause);
+
+            expect(controlScope.isPausing()).to.be.true;
+        });
+
+        it('should return false when there is no Pause taking effect', function () {
+            expect(controlScope.isPausing()).to.be.false;
+        });
+    });
+
+    describe('markPaused()', function () {
+        var pause;
+
+        beforeEach(function () {
+            pause = sinon.createStubInstance(Pause);
+        });
+
+        it('should throw when no Pause is taking effect', function () {
+            expect(function () {
+                controlScope.markPaused(pause);
+            }).to.throw(
+                Exception,
+                'ControlScope.markPaused() :: Invalid state - no pause is currently taking effect'
+            );
+        });
+
+        it('should throw when a different Pause is taking effect', function () {
+            controlScope.markPausing(sinon.createStubInstance(Pause));
+
+            expect(function () {
+                controlScope.markPaused(pause);
+            }).to.throw(
+                Exception,
+                'ControlScope.markPaused() :: Invalid state - wrong pause'
+            );
+        });
+    });
+
+    describe('markPausing()', function () {
+        var pause;
+
+        beforeEach(function () {
+            pause = sinon.createStubInstance(Pause);
+        });
+
+        it('should set the given Pause as currently taking effect', function () {
+            controlScope.markPausing(pause);
+
+            expect(controlScope.isPausing()).to.be.true;
+        });
+
+        it('should throw when a Pause is already taking effect', function () {
+            controlScope.markPausing(sinon.createStubInstance(Pause));
+
+            expect(function () {
+                controlScope.markPausing(pause);
+            }).to.throw(
+                Exception,
+                'ControlScope.markPausing() :: Invalid state - a pause is already taking effect'
+            );
+        });
+    });
+
+    describe('nestCoroutine()', function () {
+        it('should throw when the next Coroutine has already been marked for nesting', function () {
+            controlScope.nestCoroutine();
+
+            expect(function () {
+                controlScope.nestCoroutine();
+            }).to.throw(
+                Exception,
+                'ControlScope.nestCoroutine() :: Invalid state - already marked for nesting'
+            );
+        });
+    });
+
+    describe('resumeCoroutine()', function () {
+        var coroutine;
+
+        beforeEach(function () {
+            coroutine = sinon.createStubInstance(Coroutine);
+        });
+
+        describe('when there is no current Coroutine', function () {
+            it('should resume the given Coroutine', function () {
+                controlScope.resumeCoroutine(coroutine);
+
+                expect(coroutine.resume).to.have.been.calledOnce;
+            });
+
+            it('should set the given Coroutine as current', function () {
+                controlScope.resumeCoroutine(coroutine);
+
+                expect(controlScope.getCoroutine()).to.equal(coroutine);
+            });
+        });
+
+        describe('when there is a current Coroutine', function () {
+            var previousCoroutine;
+
+            beforeEach(function () {
+                previousCoroutine = controlScope.enterCoroutine();
+            });
+
+            it('should suspend the previous Coroutine', function () {
+                controlScope.resumeCoroutine(coroutine);
+
+                expect(previousCoroutine.suspend).to.have.been.calledOnce;
+            });
+
+            it('should resume the given Coroutine', function () {
+                controlScope.resumeCoroutine(coroutine);
+
+                expect(coroutine.resume).to.have.been.calledOnce;
+            });
+
+            it('should resume the given Coroutine after suspending the previous one', function () {
+                controlScope.resumeCoroutine(coroutine);
+
+                expect(coroutine.resume).to.have.been.calledAfter(previousCoroutine.suspend);
+            });
+
+            it('should set the given coroutine as current', function () {
+                controlScope.resumeCoroutine(coroutine);
+
+                expect(controlScope.getCoroutine()).to.equal(coroutine);
+            });
+        });
+
+        it('should throw when a Pause is currently taking effect', function () {
+            var pause = sinon.createStubInstance(Pause);
+            controlScope.markPausing(pause);
+
+            expect(function () {
+                controlScope.resumeCoroutine(coroutine);
+            }).to.throw(
+                Exception,
+                'ControlScope.resumeCoroutine() :: Invalid state - a pause is currently taking effect'
+            );
+        });
+    });
+});

--- a/test/unit/Control/CoroutineFactoryTest.js
+++ b/test/unit/Control/CoroutineFactoryTest.js
@@ -1,0 +1,74 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    sinon = require('sinon'),
+    tools = require('../tools'),
+    CallStack = require('../../../src/CallStack'),
+    CoroutineFactory = require('../../../src/Control/CoroutineFactory'),
+    RealCoroutine = require('../../../src/Control/Coroutine'),
+    Scope = require('../../../src/Scope').sync();
+
+describe('CoroutineFactory', function () {
+    var callStack,
+        Coroutine,
+        factory,
+        scope,
+        state;
+
+    beforeEach(function () {
+        callStack = sinon.createStubInstance(CallStack);
+        state = tools.createIsolatedState('async', {
+            'call_stack': callStack
+        });
+        Coroutine = sinon.stub();
+        scope = sinon.createStubInstance(Scope);
+
+        callStack.getCurrentScope.returns(scope);
+
+        factory = new CoroutineFactory(Coroutine, callStack);
+    });
+
+    describe('createCoroutine()', function () {
+        var createdCoroutine;
+
+        beforeEach(function () {
+            createdCoroutine = sinon.createStubInstance(RealCoroutine);
+            Coroutine.returns(createdCoroutine);
+        });
+
+        it('should create the Coroutine correctly', function () {
+            factory.createCoroutine();
+
+            expect(Coroutine).to.have.been.calledOnce;
+            expect(Coroutine).to.have.been.calledWith(sinon.match.same(callStack));
+        });
+
+        it('should return the created Coroutine', function () {
+            expect(factory.createCoroutine()).to.equal(createdCoroutine);
+        });
+
+        it('should update the Scope with the created Coroutine when there is a current one', function () {
+            factory.createCoroutine();
+
+            expect(scope.updateCoroutine).to.have.been.calledOnce;
+            expect(scope.updateCoroutine).to.have.been.calledWith(sinon.match.same(createdCoroutine));
+        });
+
+        it('should not throw when there is no current Scope', function () {
+            callStack.getCurrentScope.returns(null);
+
+            expect(function () {
+                factory.createCoroutine();
+            }).not.to.throw();
+        });
+    });
+});

--- a/test/unit/Control/CoroutineTest.js
+++ b/test/unit/Control/CoroutineTest.js
@@ -1,0 +1,86 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    phpCommon = require('phpcommon'),
+    sinon = require('sinon'),
+    tools = require('../tools'),
+    Call = require('../../../src/Call'),
+    CallStack = require('../../../src/CallStack'),
+    Coroutine = require('../../../src/Control/Coroutine'),
+    Exception = phpCommon.Exception;
+
+describe('Coroutine', function () {
+    var calls,
+        callStack,
+        coroutine,
+        state;
+
+    beforeEach(function () {
+        callStack = sinon.createStubInstance(CallStack);
+        state = tools.createIsolatedState('async', {
+            'call_stack': callStack
+        });
+        calls = [sinon.createStubInstance(Call), sinon.createStubInstance(Call)];
+
+        callStack.save.returns(calls);
+
+        coroutine = new Coroutine(callStack);
+    });
+
+    describe('resume()', function () {
+        it('should restore the CallStack when the Coroutine has been suspended', function () {
+            coroutine.suspend();
+
+            coroutine.resume();
+
+            expect(callStack.restore).to.have.been.calledOnce;
+            expect(callStack.restore).to.have.been.calledWith(sinon.match.same(calls));
+        });
+
+        it('should not restore the CallStack when the Coroutine has not been suspended', function () {
+            coroutine.resume();
+
+            expect(callStack.restore).not.to.have.been.called;
+        });
+    });
+
+    describe('suspend()', function () {
+        it('should save the CallStack', function () {
+            coroutine.suspend();
+
+            expect(callStack.save).to.have.been.calledOnce;
+        });
+
+        it('should clear the CallStack', function () {
+            coroutine.suspend();
+
+            expect(callStack.clear).to.have.been.calledOnce;
+        });
+
+        it('should clear the CallStack after saving', function () {
+            coroutine.suspend();
+
+            expect(callStack.clear).to.have.been.calledAfter(callStack.save);
+        });
+
+        it('should throw when the Coroutine has already been suspended', function () {
+            coroutine.suspend();
+
+            expect(function () {
+                coroutine.suspend();
+            }).to.throw(
+                Exception,
+                'Coroutine.save() :: Invalid state - coroutine already suspended'
+            );
+        });
+    });
+});

--- a/test/unit/Engine/EngineScopeTest.js
+++ b/test/unit/Engine/EngineScopeTest.js
@@ -1,0 +1,83 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    sinon = require('sinon'),
+    ControlScope = require('../../../src/Control/ControlScope'),
+    Coroutine = require('../../../src/Control/Coroutine'),
+    EngineScope = require('../../../src/Engine/EngineScope'),
+    Scope = require('../../../src/Scope').sync();
+
+describe('EngineScope', function () {
+    var controlScope,
+        coroutine,
+        effectiveScope,
+        scope;
+
+    beforeEach(function () {
+        controlScope = sinon.createStubInstance(ControlScope);
+        coroutine = sinon.createStubInstance(Coroutine);
+        effectiveScope = sinon.createStubInstance(Scope);
+
+        scope = new EngineScope(effectiveScope, controlScope, coroutine);
+    });
+
+    describe('enterCoroutine()', function () {
+        it('should resume the current Coroutine for the Scope when it has one', function () {
+            scope.enterCoroutine();
+
+            expect(controlScope.resumeCoroutine).to.have.been.calledOnce;
+            expect(controlScope.resumeCoroutine).to.have.been.calledWith(
+                sinon.match.same(coroutine)
+            );
+        });
+
+        describe('when the Scope has no current Coroutine', function () {
+            var newCoroutine;
+
+            beforeEach(function () {
+                newCoroutine = sinon.createStubInstance(Coroutine);
+
+                controlScope.enterCoroutine.returns(newCoroutine);
+
+                scope = new EngineScope(effectiveScope, controlScope, null);
+            });
+
+            it('should enter a new current Coroutine for the Scope', function () {
+                scope.enterCoroutine();
+
+                expect(controlScope.enterCoroutine).to.have.been.calledOnce;
+            });
+
+            it('should update the Scope with the new Coroutine', function () {
+                scope.enterCoroutine();
+
+                expect(scope.getCoroutine()).to.equal(newCoroutine);
+            });
+        });
+    });
+
+    describe('getCoroutine()', function () {
+        it('should return the current Coroutine for the Scope', function () {
+            expect(scope.getCoroutine()).to.equal(coroutine);
+        });
+    });
+
+    describe('updateCoroutine()', function () {
+        it('should update the current Coroutine for the Scope', function () {
+            var newCoroutine = sinon.createStubInstance(Coroutine);
+
+            scope.updateCoroutine(newCoroutine);
+
+            expect(scope.getCoroutine()).to.equal(newCoroutine);
+        });
+    });
+});

--- a/test/unit/EngineTest.js
+++ b/test/unit/EngineTest.js
@@ -172,17 +172,19 @@ describe('Engine', function () {
 
     describe('defineGlobalAccessor()', function () {
         it('should define a global accessor on the environment', function () {
-            var valueGetter = sinon.stub(),
+            var referenceSetter = sinon.stub(),
+                valueGetter = sinon.stub(),
                 valueSetter = sinon.stub();
             createEngine();
 
-            engine.defineGlobalAccessor('my_global', valueGetter, valueSetter);
+            engine.defineGlobalAccessor('my_global', valueGetter, valueSetter, referenceSetter);
 
             expect(environment.defineGlobalAccessor).to.have.been.calledOnce;
             expect(environment.defineGlobalAccessor).to.have.been.calledWith(
                 'my_global',
                 sinon.match.same(valueGetter),
-                sinon.match.same(valueSetter)
+                sinon.match.same(valueSetter),
+                sinon.match.same(referenceSetter)
             );
         });
     });

--- a/test/unit/EnvironmentTest.js
+++ b/test/unit/EnvironmentTest.js
@@ -143,15 +143,17 @@ describe('Environment', function () {
 
     describe('defineGlobalAccessor()', function () {
         it('should define the global on the state', function () {
-            var valueGetter = sinon.stub(),
+            var referenceSetter = sinon.stub(),
+                valueGetter = sinon.stub(),
                 valueSetter = sinon.spy();
-            environment.defineGlobalAccessor('myGlobal', valueGetter, valueSetter);
+            environment.defineGlobalAccessor('myGlobal', valueGetter, valueSetter, referenceSetter);
 
             expect(state.defineGlobalAccessor).to.have.been.calledOnce;
             expect(state.defineGlobalAccessor).to.have.been.calledWith(
                 'myGlobal',
                 sinon.match.same(valueGetter),
-                sinon.match.same(valueSetter)
+                sinon.match.same(valueSetter),
+                sinon.match.same(referenceSetter)
             );
         });
     });

--- a/test/unit/FFI/FFIFactoryTest.js
+++ b/test/unit/FFI/FFIFactoryTest.js
@@ -16,6 +16,7 @@ var expect = require('chai').expect,
     FFIFactory = require('../../../src/FFI/FFIFactory'),
     NativeCaller = require('../../../src/FFI/Call/NativeCaller').sync(),
     ObjectValue = require('../../../src/Value/Object').sync(),
+    Value = require('../../../src/Value').sync(),
     ValueCaller = require('../../../src/FFI/Call/ValueCaller').sync();
 
 describe('FFIFactory', function () {
@@ -27,6 +28,7 @@ describe('FFIFactory', function () {
         nativeCaller,
         PHPObject,
         referenceFactory,
+        ResultValue,
         state,
         valueCaller,
         ValueCoercer,
@@ -43,6 +45,7 @@ describe('FFIFactory', function () {
         nativeCaller = sinon.createStubInstance(NativeCaller);
         PHPObject = sinon.stub();
         referenceFactory = state.getReferenceFactory();
+        ResultValue = sinon.stub();
         valueCaller = sinon.createStubInstance(ValueCaller);
         ValueCoercer = sinon.stub();
         valueFactory = state.getValueFactory();
@@ -50,6 +53,7 @@ describe('FFIFactory', function () {
         factory = new FFIFactory(
             AsyncObjectValue,
             PHPObject,
+            ResultValue,
             ValueCoercer,
             valueFactory,
             referenceFactory,
@@ -107,6 +111,31 @@ describe('FFIFactory', function () {
             PHPObject.returns(phpObject);
 
             expect(factory.createPHPObject(objectValue)).to.equal(phpObject);
+        });
+    });
+
+    describe('createResultValue()', function () {
+        var internalValue;
+
+        beforeEach(function () {
+            internalValue = sinon.createStubInstance(Value);
+        });
+
+        it('should correctly construct the new ResultValue instance', function () {
+            factory.createResultValue(internalValue, 'my native value');
+
+            expect(ResultValue).to.have.been.calledOnce;
+            expect(ResultValue).to.have.been.calledWith(
+                sinon.match.same(internalValue),
+                'my native value'
+            );
+        });
+
+        it('should return the created ResultValue instance', function () {
+            var resultValue = sinon.createStubInstance(ResultValue);
+            ResultValue.returns(resultValue);
+
+            expect(factory.createResultValue(internalValue, 'my native value')).to.equal(resultValue);
         });
     });
 

--- a/test/unit/FFI/Value/ResultValueTest.js
+++ b/test/unit/FFI/Value/ResultValueTest.js
@@ -1,0 +1,90 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    sinon = require('sinon'),
+    tools = require('../../tools'),
+    ResultValue = require('../../../../src/FFI/Value/ResultValue'),
+    Value = require('../../../../src/Value').sync();
+
+describe('ResultValue', function () {
+    var internalValue,
+        nativeValue,
+        presentNativeValue,
+        proxyValue,
+        state,
+        value,
+        valueFactory;
+
+    beforeEach(function () {
+        state = tools.createIsolatedState();
+        valueFactory = state.getValueFactory();
+        internalValue = sinon.createStubInstance(Value);
+        nativeValue = {my: 'real native value'};
+        presentNativeValue = {my: 'present native value'};
+        proxyValue = {my: 'proxy value'};
+
+        internalValue.getType.returns('object');
+        internalValue.getNative.returns(nativeValue);
+        internalValue.getProxy.returns(proxyValue);
+
+        value = new ResultValue(internalValue, presentNativeValue);
+    });
+
+    describe('getInternalValue()', function () {
+        it('should return the internal Value', function () {
+            expect(value.getInternalValue()).to.equal(internalValue);
+        });
+    });
+
+    describe('getNative()', function () {
+        it('should return the present native value', function () {
+            expect(value.getNative()).to.equal(presentNativeValue);
+        });
+    });
+
+    describe('getProxy()', function () {
+        it('should return the proxy for an internal ObjectValue', function () {
+            internalValue.getType.returns('object');
+
+            expect(value.getProxy()).to.equal(proxyValue);
+        });
+
+        it('should return the present native value for an internal non-object Value', function () {
+            internalValue.getType.returns('string');
+            internalValue.getNative.returns('my string');
+
+            expect(value.getProxy()).to.equal(presentNativeValue);
+        });
+    });
+
+    describe('getStatus()', function () {
+        it('should return the status for an internal ExitValue', function () {
+            internalValue.getType.returns('exit');
+            internalValue.getStatus.returns(21);
+
+            expect(value.getStatus()).to.equal(21);
+        });
+
+        it('should return null for an internal non-exit Value', function () {
+            internalValue.getType.returns('string');
+            internalValue.getNative.returns('my string');
+
+            expect(value.getStatus()).to.be.null;
+        });
+    });
+
+    describe('getType()', function () {
+        it('should return the type of the internal Value', function () {
+            expect(value.getType()).to.equal('object');
+        });
+    });
+});

--- a/test/unit/FunctionFactoryTest.js
+++ b/test/unit/FunctionFactoryTest.js
@@ -16,7 +16,6 @@ var expect = require('chai').expect,
     CallFactory = require('../../src/CallFactory'),
     CallStack = require('../../src/CallStack'),
     Class = require('../../src/Class').sync(),
-    ControlBridge = require('../../src/Control/ControlBridge'),
     ControlScope = require('../../src/Control/ControlScope'),
     FunctionFactory = require('../../src/FunctionFactory').sync(),
     FunctionSpec = require('../../src/Function/FunctionSpec'),
@@ -46,12 +45,16 @@ describe('FunctionFactory', function () {
         valueFactory;
 
     beforeEach(function () {
-        state = tools.createIsolatedState();
-        call = sinon.createStubInstance(Call);
+        controlScope = sinon.createStubInstance(ControlScope);
         callFactory = sinon.createStubInstance(CallFactory);
         callStack = sinon.createStubInstance(CallStack);
-        controlBridge = sinon.createStubInstance(ControlBridge);
-        controlScope = sinon.createStubInstance(ControlScope);
+        state = tools.createIsolatedState('async', {
+            'call_factory': callFactory,
+            'call_stack': callStack,
+            'control_scope': controlScope
+        });
+        call = sinon.createStubInstance(Call);
+        controlBridge = state.getControlBridge();
         currentClass = sinon.createStubInstance(Class);
         flow = state.getFlow();
         futureFactory = state.getFutureFactory();

--- a/test/unit/KeyValuePairTest.js
+++ b/test/unit/KeyValuePairTest.js
@@ -1,0 +1,61 @@
+/*
+ * PHPCore - PHP environment runtime components
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/uniter/phpcore/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phpcore/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var expect = require('chai').expect,
+    tools = require('./tools'),
+    KeyValuePair = require('../../src/KeyValuePair');
+
+describe('KeyValuePair', function () {
+    var key,
+        pair,
+        state,
+        value,
+        valueFactory;
+
+    beforeEach(function () {
+        state = tools.createIsolatedState('async');
+        valueFactory = state.getValueFactory();
+        key = valueFactory.createString('my_key');
+        value = valueFactory.createString('my value');
+
+        pair = new KeyValuePair(key, value);
+    });
+
+    describe('asArrayElement()', function () {
+        it('should return the pair unchanged when the value is present', function () {
+            expect(pair.asArrayElement()).to.equal(pair);
+        });
+
+        it('should return a Future that resolves with a pair with the value resolved when needed', async function () {
+            var result;
+            value = valueFactory.createAsyncPresent('my string');
+            pair = new KeyValuePair(key, value);
+
+            result = await pair.asArrayElement().toPromise();
+
+            expect(result).not.to.equal(pair);
+            expect(result.getKey()).to.equal(key);
+            expect(result.getValue().getNative()).to.equal('my string');
+        });
+    });
+
+    describe('getKey()', function () {
+        it('should return the value of the key of the pair', function () {
+            expect(pair.getKey()).to.equal(key);
+        });
+    });
+
+    describe('getValue()', function () {
+        it('should return the value of the pair', function () {
+            expect(pair.getValue()).to.equal(value);
+        });
+    });
+});

--- a/test/unit/Reference/AccessorReferenceTest.js
+++ b/test/unit/Reference/AccessorReferenceTest.js
@@ -57,6 +57,14 @@ describe('AccessorReference', function () {
         });
     });
 
+    describe('asEventualNative()', function () {
+        it('should return a Future that resolves to the native value returned by the getter', async function () {
+            valueGetter.returns(101);
+
+            expect(await reference.asEventualNative().toPromise()).to.equal(101);
+        });
+    });
+
     describe('formatAsString()', function () {
         it('should return the native result of the getter, formatted', function () {
             valueGetter.returns('My native result');
@@ -95,6 +103,24 @@ describe('AccessorReference', function () {
 
         it('should return a NullValue when the getter returns no value', function () {
             expect(reference.getValueOrNull().getType()).to.equal('null');
+        });
+    });
+
+    describe('hasReferenceSetter()', function () {
+        it('should return true when a reference setter was given', function () {
+            expect(reference.hasReferenceSetter()).to.be.true;
+        });
+
+        it('should return false when a reference setter was not given', function () {
+            reference = new AccessorReference(
+                valueFactory,
+                referenceFactory,
+                valueGetter,
+                valueSetter,
+                null
+            );
+
+            expect(reference.hasReferenceSetter()).to.be.false;
         });
     });
 
@@ -181,6 +207,18 @@ describe('AccessorReference', function () {
             var newValue = valueFactory.createString('my new value');
 
             expect(await reference.setValue(newValue).toPromise()).to.equal(newValue);
+        });
+    });
+
+    describe('toPromise()', function () {
+        it('should return a Promise that resolves with the eventual Value from the getter', async function () {
+            var resultValue;
+            valueGetter.returns(101);
+
+            resultValue = await reference.toPromise();
+
+            expect(resultValue.getType()).to.equal('int');
+            expect(resultValue.getNative()).to.equal(101);
         });
     });
 });

--- a/test/unit/Reference/ElementTest.js
+++ b/test/unit/Reference/ElementTest.js
@@ -46,9 +46,11 @@ describe('ElementReference', function () {
         value = sinon.createStubInstance(Value);
 
         value.formatAsString.returns('\'the value of my...\'');
+        value.asEventualNative.returns(futureFactory.createPresent('the value of my element'));
         value.getForAssignment.returns(value);
         value.getNative.returns('the value of my element');
         value.getType.returns('string');
+        value.toPromise.returns(Promise.resolve(value));
 
         element = new ElementReference(
             valueFactory,
@@ -65,6 +67,12 @@ describe('ElementReference', function () {
     describe('asArrayElement()', function () {
         it('should return the element\'s value', function () {
             expect(element.asArrayElement()).to.equal(value);
+        });
+    });
+
+    describe('asEventualNative()', function () {
+        it('should return a Future that resolves to the native value of the element', async function () {
+            expect(await element.asEventualNative().toPromise()).to.equal('the value of my element');
         });
     });
 
@@ -258,6 +266,12 @@ describe('ElementReference', function () {
             );
 
             expect(element.getValueReference()).to.be.null;
+        });
+    });
+
+    describe('hasReferenceSetter()', function () {
+        it('should return false', function () {
+            expect(element.hasReferenceSetter()).to.be.false;
         });
     });
 
@@ -467,6 +481,15 @@ describe('ElementReference', function () {
 
                 expect(arrayValue.pointToElement).not.to.have.been.called;
             });
+        });
+    });
+
+    describe('toPromise()', function () {
+        it('should return a Promise that resolves with the Value of the element', async function () {
+            var resultValue = await element.toPromise();
+
+            expect(resultValue.getType()).to.equal('string');
+            expect(resultValue.getNative()).to.equal('the value of my element');
         });
     });
 

--- a/test/unit/Reference/NullTest.js
+++ b/test/unit/Reference/NullTest.js
@@ -39,6 +39,12 @@ describe('NullReference', function () {
         });
     });
 
+    describe('asEventualNative()', function () {
+        it('should return a Future that resolves to null', async function () {
+            expect(await reference.asEventualNative().toPromise()).to.be.null;
+        });
+    });
+
     describe('formatAsString()', function () {
         it('should return "NULL"', function () {
             expect(reference.formatAsString()).to.equal('NULL');
@@ -60,6 +66,12 @@ describe('NullReference', function () {
     describe('getValueOrNull()', function () {
         it('should return a NullValue', function () {
             expect(reference.getValueOrNull().getType()).to.equal('null');
+        });
+    });
+
+    describe('hasReferenceSetter()', function () {
+        it('should return false', function () {
+            expect(reference.hasReferenceSetter()).to.be.false;
         });
     });
 
@@ -98,6 +110,14 @@ describe('NullReference', function () {
             var value = sinon.createStubInstance(Value);
 
             expect(reference.setValue(value)).to.equal(value);
+        });
+    });
+
+    describe('toPromise()', function () {
+        it('should return a Promise that resolves to a NullValue', async function () {
+            var resultValue = await reference.toPromise();
+
+            expect(resultValue.getType()).to.equal('null');
         });
     });
 });

--- a/test/unit/Reference/ObjectElementTest.js
+++ b/test/unit/Reference/ObjectElementTest.js
@@ -58,6 +58,17 @@ describe('ObjectElementReference', function () {
         });
     });
 
+    describe('asEventualNative()', function () {
+        it('should return a Future that resolves to the native value from ArrayAccess::offsetGet(...)', async function () {
+            objectValue.callMethod.withArgs(
+                'offsetGet',
+                sinon.match([sinon.match.same(keyValue)])
+            ).returns(valueFactory.createString('my value'));
+
+            expect(await element.asEventualNative().toPromise()).to.equal('my value');
+        });
+    });
+
     describe('getNative()', function () {
         it('should return the native value of the result from ArrayAccess::offsetGet(...)', function () {
             expect(element.getNative()).to.equal('hello');
@@ -73,6 +84,12 @@ describe('ObjectElementReference', function () {
             ).returns(value);
 
             expect(element.getValueOrNull()).to.equal(value);
+        });
+    });
+
+    describe('hasReferenceSetter()', function () {
+        it('should return false', function () {
+            expect(element.hasReferenceSetter()).to.be.false;
         });
     });
 
@@ -201,6 +218,21 @@ describe('ObjectElementReference', function () {
 
             expect(resultPresent.getType()).to.equal('string');
             expect(resultPresent.getNative()).to.equal('my final assigned value');
+        });
+    });
+
+    describe('toPromise()', function () {
+        it('should return a Promise that resolves with the Value from ArrayAccess::offsetGet(...)', async function () {
+            var resultValue;
+            objectValue.callMethod.withArgs(
+                'offsetGet',
+                sinon.match([sinon.match.same(keyValue)])
+            ).returns(valueFactory.createString('my value'));
+
+            resultValue = await element.toPromise();
+
+            expect(resultValue.getType()).to.equal('string');
+            expect(resultValue.getNative()).to.equal('my value');
         });
     });
 

--- a/test/unit/Reference/PropertyTest.js
+++ b/test/unit/Reference/PropertyTest.js
@@ -53,10 +53,12 @@ describe('PropertyReference', function () {
         classObject.getName.returns('My\\AwesomeClass');
         keyValue.getNative.returns('my_property');
         keyValue.getType.returns('string');
+        propertyValue.asEventualNative.returns(futureFactory.createPresent('value for my prop'));
         propertyValue.formatAsString.returns('\'the value of my...\'');
         propertyValue.getForAssignment.returns(propertyValue);
         propertyValue.getNative.returns('value for my prop');
         propertyValue.getType.returns('string');
+        propertyValue.toPromise.returns(Promise.resolve(propertyValue));
 
         createProperty = function (visibility) {
             property = new PropertyReference(
@@ -79,6 +81,14 @@ describe('PropertyReference', function () {
             property.initialise(propertyValue);
 
             expect(property.asArrayElement()).to.equal(propertyValue);
+        });
+    });
+
+    describe('asEventualNative()', function () {
+        it('should return a Future that resolves to the native value of the property', async function () {
+            property.initialise(propertyValue);
+
+            expect(await property.asEventualNative().toPromise()).to.equal('value for my prop');
         });
     });
 
@@ -300,6 +310,12 @@ describe('PropertyReference', function () {
         });
     });
 
+    describe('hasReferenceSetter()', function () {
+        it('should return false', function () {
+            expect(property.hasReferenceSetter()).to.be.false;
+        });
+    });
+
     describe('initialise()', function () {
         it('should set the value of the property', function () {
             property.initialise(propertyValue);
@@ -518,6 +534,18 @@ describe('PropertyReference', function () {
                     expect(resultValue.getNative()).to.equal('my new value');
                 });
             });
+        });
+    });
+
+    describe('toPromise()', function () {
+        it('should return a Promise that resolves with the Value of the property', async function () {
+            var resultValue;
+            property.initialise(propertyValue);
+
+            resultValue = await property.toPromise();
+
+            expect(resultValue.getType()).to.equal('string');
+            expect(resultValue.getNative()).to.equal('value for my prop');
         });
     });
 

--- a/test/unit/Reference/ReferenceSlotTest.js
+++ b/test/unit/Reference/ReferenceSlotTest.js
@@ -43,6 +43,14 @@ describe('ReferenceSlot', function () {
         });
     });
 
+    describe('asEventualNative()', function () {
+        it('should return a Future that resolves to the native value of the slot', async function () {
+            reference.setValue(valueFactory.createString('my value'));
+
+            expect(await reference.asEventualNative().toPromise()).to.equal('my value');
+        });
+    });
+
     describe('getForAssignment()', function () {
         it('should return the value of the slot', function () {
             var result = sinon.createStubInstance(Value);
@@ -82,6 +90,12 @@ describe('ReferenceSlot', function () {
         });
     });
 
+    describe('hasReferenceSetter()', function () {
+        it('should return false', function () {
+            expect(reference.hasReferenceSetter()).to.be.false;
+        });
+    });
+
     describe('isReferenceable()', function () {
         it('should return true', function () {
             expect(reference.isReferenceable()).to.be.true;
@@ -101,6 +115,18 @@ describe('ReferenceSlot', function () {
             var newValue = sinon.createStubInstance(Value);
 
             expect(reference.setValue(newValue)).to.equal(newValue);
+        });
+    });
+
+    describe('toPromise()', function () {
+        it('should return a Promise that resolves with the Value of the slot', async function () {
+            var resultValue;
+            reference.setValue(valueFactory.createString('my value'));
+
+            resultValue = await reference.toPromise();
+
+            expect(resultValue.getType()).to.equal('string');
+            expect(resultValue.getNative()).to.equal('my value');
         });
     });
 });

--- a/test/unit/Reference/ReferenceSlotTest.js
+++ b/test/unit/Reference/ReferenceSlotTest.js
@@ -30,8 +30,16 @@ describe('ReferenceSlot', function () {
     });
 
     describe('asArrayElement()', function () {
-        it('should return the ReferenceSlot itself', function () {
-            expect(reference.asArrayElement()).to.equal(reference);
+        it('should return the value of the slot for assignment', function () {
+            var result,
+                resultValue = sinon.createStubInstance(Value);
+            resultValue.getForAssignment.returns(valueFactory.createString('my value for assignment'));
+            reference.setValue(resultValue);
+
+            result = reference.asArrayElement();
+
+            expect(result.getType()).to.equal('string');
+            expect(result.getNative()).to.equal('my value for assignment');
         });
     });
 

--- a/test/unit/Reference/UndeclaredStaticPropertyReferenceTest.js
+++ b/test/unit/Reference/UndeclaredStaticPropertyReferenceTest.js
@@ -64,6 +64,16 @@ describe('UndeclaredStaticPropertyReference', function () {
         });
     });
 
+    describe('asEventualNative()', function () {
+        it('should raise an error', function () {
+            expect(function () {
+                reference.asEventualNative();
+            }).to.throw(
+                'Fake PHP Fatal error for #core.undeclared_static_property with {"propertyName":"myProperty"}'
+            );
+        });
+    });
+
     describe('formatAsString()', function () {
         it('should return "NULL"', function () {
             expect(reference.formatAsString()).to.equal('NULL');
@@ -83,6 +93,12 @@ describe('UndeclaredStaticPropertyReference', function () {
     describe('getValueOrNull()', function () {
         it('should return a NullValue', function () {
             expect(reference.getValueOrNull().getType()).to.equal('null');
+        });
+    });
+
+    describe('hasReferenceSetter()', function () {
+        it('should return false', function () {
+            expect(reference.hasReferenceSetter()).to.be.false;
         });
     });
 
@@ -114,6 +130,16 @@ describe('UndeclaredStaticPropertyReference', function () {
         it('should raise an error', function () {
             expect(function () {
                 reference.setValue(sinon.createStubInstance(Value));
+            }).to.throw(
+                'Fake PHP Fatal error for #core.undeclared_static_property with {"propertyName":"myProperty"}'
+            );
+        });
+    });
+
+    describe('toPromise()', function () {
+        it('should raise an error', function () {
+            expect(function () {
+                reference.toPromise();
             }).to.throw(
                 'Fake PHP Fatal error for #core.undeclared_static_property with {"propertyName":"myProperty"}'
             );

--- a/test/unit/Value/FutureTest.js
+++ b/test/unit/Value/FutureTest.js
@@ -455,7 +455,7 @@ describe('FutureValue', function () {
 
     describe('getNative()', function () {
         it('should throw even when the future is already resolved', function () {
-            createValue(futureFactory.createAsyncPresent(factory.createString('my result')));
+            createValue(futureFactory.createPresent(factory.createString('my result')));
 
             expect(function () {
                 value.getNative();
@@ -505,7 +505,7 @@ describe('FutureValue', function () {
 
     describe('getType()', function () {
         it('should return "future" even when the future is already resolved', function () {
-            createValue(futureFactory.createAsyncPresent(factory.createString('my result')));
+            createValue(futureFactory.createPresent(factory.createString('my result')));
 
             expect(value.getType()).to.equal('future');
         });

--- a/test/unit/ValueTest.js
+++ b/test/unit/ValueTest.js
@@ -108,6 +108,8 @@ describe('Value', function () {
 
                 propertyRef.setValue.callsFake(function (value) {
                     nativeStdClassObject[nameValue.getNative()] = value.getNative();
+
+                    return value;
                 });
 
                 return propertyRef;

--- a/test/unit/VariableTest.js
+++ b/test/unit/VariableTest.js
@@ -61,6 +61,14 @@ describe('Variable', function () {
         });
     });
 
+    describe('asEventualNative()', function () {
+        it('should return the native value of the variable', async function () {
+            variable.setValue(valueFactory.createPresent(1234));
+
+            expect(await variable.asEventualNative().toPromise()).to.equal(1234);
+        });
+    });
+
     describe('formatAsString()', function () {
         it('should format the value when the variable is defined with a value', function () {
             variable.setValue(valueFactory.createString('my value'));
@@ -260,10 +268,27 @@ describe('Variable', function () {
     });
 
     describe('setReference()', function () {
-        it('should return the variable', function () {
-            var reference = sinon.createStubInstance(Reference);
+        var reference;
 
+        beforeEach(function () {
+            reference = sinon.createStubInstance(Reference);
+        });
+
+        it('should return the variable', function () {
             expect(variable.setReference(reference)).to.equal(variable);
+        });
+
+        it('should invoke an existing reference when it has a reference setter', function () {
+            var existingReference = sinon.createStubInstance(Reference);
+            existingReference.hasReferenceSetter.returns(true);
+            variable.setReference(existingReference);
+
+            variable.setReference(reference);
+
+            expect(existingReference.setReference).to.have.been.calledOnce;
+            expect(existingReference.setReference).to.have.been.calledWith(
+                sinon.match.same(reference)
+            );
         });
     });
 
@@ -330,6 +355,18 @@ describe('Variable', function () {
             value = await variable.setValue(valueFactory.createNull()).toPromise();
 
             expect(value.getType()).to.equal('null');
+        });
+    });
+
+    describe('toPromise()', function () {
+        it('should return a Promise resolved with the value of the variable', async function () {
+            var value;
+            variable.setValue(valueFactory.createInteger(1234));
+
+            value = await variable.toPromise();
+
+            expect(value.getType()).to.equal('int');
+            expect(value.getNative()).to.equal(1234);
         });
     });
 


### PR DESCRIPTION
Adds support for re-entrancy to the runtime. PHP userland call stacks are represented as `Coroutine`s, which may now be suspended and later resumed.

Together with the recent async mode refactor, this allows PHP code using the blocking PHP-land APIs to integrate with native JS-land code without blocking the event loop.